### PR TITLE
入力バリデーション強化・持ち時間二重減算修正・RateLimiter掃除を追加

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,7 +8,7 @@ import { RealtimeHub } from "./realtime";
 import { respond, respondError } from "./respond";
 import { ROUTE_JOIN, ROUTE_MOVE, ROUTE_RECORDS, ROUTE_RESIGN, ROUTE_SNAPSHOT } from "./routePatterns";
 import { InMemoryStore } from "./store";
-import type { CreateGameInput, JoinGameInput, Player } from "./types";
+import type { Player } from "./types";
 import { isMoveRequestBody, isValidCreateGameInput, isValidJoinGameInput } from "./validators";
 
 const store = new InMemoryStore();
@@ -54,7 +54,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   }
 
   if (req.method === "POST" && req.url === "/api/games") {
-    const body = await readJsonBody<CreateGameInput>(req);
+    const body = await readJsonBody<unknown>(req);
     if (!isValidCreateGameInput(body)) {
       respondError(res, ctx, 400, "INVALID_CREATE_GAME_PAYLOAD", "Invalid create game payload");
       return;
@@ -69,7 +69,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   const joinMatch = req.url?.match(ROUTE_JOIN);
   if (req.method === "POST" && joinMatch) {
     const gameId = joinMatch[1];
-    const body = await readJsonBody<JoinGameInput>(req);
+    const body = await readJsonBody<unknown>(req);
     if (!isValidJoinGameInput(body)) {
       respondError(res, ctx, 400, "INVALID_JOIN_PAYLOAD", "Invalid join payload", { gameId });
       return;
@@ -207,6 +207,10 @@ export function createApp() {
     handleRequest(req, res).catch((error: unknown) => {
       const ctx = makeRequestContext(req);
       const message = getErrorCode(error, "Internal Server Error");
+      if (message === "INVALID_JSON") {
+        respondError(res, ctx, 400, "INVALID_JSON", "Malformed JSON payload");
+        return;
+      }
       log({
         level: "error",
         event: "http.error",

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -18,5 +18,9 @@ export async function readJsonBody<T>(req: IncomingMessage): Promise<T> {
     return {} as T;
   }
 
-  return JSON.parse(text) as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new Error("INVALID_JSON");
+  }
 }

--- a/server/src/rateLimiter.ts
+++ b/server/src/rateLimiter.ts
@@ -5,14 +5,29 @@ type Bucket = {
 
 export class RateLimiter {
   private readonly buckets = new Map<string, Bucket>();
+  private lastCleanupAtMs = 0;
 
   constructor(
     private readonly windowMs: number,
     private readonly limit: number,
   ) {}
 
+  private cleanupExpired(now: number): void {
+    if (now - this.lastCleanupAtMs < this.windowMs) {
+      return;
+    }
+
+    for (const [key, bucket] of this.buckets.entries()) {
+      if (now - bucket.startedAtMs >= this.windowMs) {
+        this.buckets.delete(key);
+      }
+    }
+    this.lastCleanupAtMs = now;
+  }
+
   consume(key: string): boolean {
     const now = Date.now();
+    this.cleanupExpired(now);
     const current = this.buckets.get(key);
     if (!current || now - current.startedAtMs >= this.windowMs) {
       this.buckets.set(key, { startedAtMs: now, count: 1 });

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -192,8 +192,6 @@ export class InMemoryStore {
       throw new Error("NOT_YOUR_TURN");
     }
 
-    this.applyElapsedClock(game, actor.seat, Date.now());
-
     const result = applyMove(game.state, move);
     if (!result.ok) {
       throw new Error(`ILLEGAL_MOVE:${result.reason}`);

--- a/server/src/validators.ts
+++ b/server/src/validators.ts
@@ -6,18 +6,70 @@ export type MoveRequestBody = {
   expectedVersion: number;
 };
 
-export function isValidCreateGameInput(input: CreateGameInput): boolean {
-  if (!Number.isInteger(input.mainMinutes) || input.mainMinutes <= 0) {
-    return false;
-  }
-  if (!Number.isInteger(input.byoSeconds) || input.byoSeconds < 0) {
-    return false;
-  }
-  return input.byoSeconds === 0 || input.byoSeconds % 10 === 0;
+type JsonRecord = Record<string, unknown>;
+
+const DROP_KINDS = new Set(["rook", "bishop", "gold", "silver", "knight", "lance", "pawn"]);
+
+function isRecord(input: unknown): input is JsonRecord {
+  return !!input && typeof input === "object";
 }
 
-export function isValidJoinGameInput(input: JoinGameInput): boolean {
-  const trimmed = input.name?.trim();
+function isPosition(input: unknown): input is { x: number; y: number } {
+  if (!isRecord(input)) {
+    return false;
+  }
+  return (
+    Number.isInteger(input.x) &&
+    Number.isInteger(input.y) &&
+    (input.x as number) >= 0 &&
+    (input.x as number) <= 8 &&
+    (input.y as number) >= 0 &&
+    (input.y as number) <= 8
+  );
+}
+
+function isMoveShape(input: unknown): input is Move {
+  if (!isRecord(input)) {
+    return false;
+  }
+
+  if ("drop" in input) {
+    return typeof input.drop === "string" && DROP_KINDS.has(input.drop) && isPosition(input.to);
+  }
+
+  if (!isPosition(input.from) || !isPosition(input.to)) {
+    return false;
+  }
+
+  if ("promote" in input && typeof input.promote !== "boolean") {
+    return false;
+  }
+
+  return true;
+}
+
+export function isValidCreateGameInput(input: unknown): input is CreateGameInput {
+  if (!isRecord(input)) {
+    return false;
+  }
+
+  if (!Number.isInteger(input.mainMinutes) || (input.mainMinutes as number) <= 0) {
+    return false;
+  }
+  if (!Number.isInteger(input.byoSeconds) || (input.byoSeconds as number) < 0) {
+    return false;
+  }
+  const byoSeconds = input.byoSeconds as number;
+  return byoSeconds === 0 || byoSeconds % 10 === 0;
+}
+
+export function isValidJoinGameInput(input: unknown): input is JoinGameInput {
+  if (!isRecord(input)) {
+    return false;
+  }
+
+  const name = typeof input.name === "string" ? input.name : "";
+  const trimmed = name.trim();
   if (!trimmed || trimmed.length < 2 || trimmed.length > 20) {
     return false;
   }
@@ -28,9 +80,11 @@ export function isValidJoinGameInput(input: JoinGameInput): boolean {
 }
 
 export function isMoveRequestBody(input: unknown): input is MoveRequestBody {
-  if (!input || typeof input !== "object") {
+  if (!isRecord(input)) {
     return false;
   }
-  const body = input as Record<string, unknown>;
-  return typeof body.expectedVersion === "number" && Number.isInteger(body.expectedVersion) && "move" in body;
+  if (!Number.isInteger(input.expectedVersion) || (input.expectedVersion as number) < 1) {
+    return false;
+  }
+  return isMoveShape(input.move);
 }

--- a/server/tests/rateLimiter.test.ts
+++ b/server/tests/rateLimiter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test, vi } from "vitest";
+import { RateLimiter } from "../src/rateLimiter";
+
+describe("RateLimiter", () => {
+  test("cleans up stale buckets while processing new keys", () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    const limiter = new RateLimiter(1_000, 10);
+
+    nowSpy.mockReturnValue(0);
+    expect(limiter.consume("ip-1")).toBe(true);
+    expect(limiter.consume("ip-2")).toBe(true);
+
+    nowSpy.mockReturnValue(2_000);
+    expect(limiter.consume("ip-3")).toBe(true);
+
+    const buckets = (limiter as unknown as { buckets: Map<string, unknown> }).buckets;
+    expect(buckets.has("ip-1")).toBe(false);
+    expect(buckets.has("ip-2")).toBe(false);
+    expect(buckets.has("ip-3")).toBe(true);
+
+    nowSpy.mockRestore();
+  });
+
+  test("still enforces per-window request limits", () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    const limiter = new RateLimiter(1_000, 2);
+
+    nowSpy.mockReturnValue(100);
+    expect(limiter.consume("same-ip")).toBe(true);
+    expect(limiter.consume("same-ip")).toBe(true);
+    expect(limiter.consume("same-ip")).toBe(false);
+
+    nowSpy.mockReturnValue(1_200);
+    expect(limiter.consume("same-ip")).toBe(true);
+
+    nowSpy.mockRestore();
+  });
+});

--- a/server/tests/storeClock.test.ts
+++ b/server/tests/storeClock.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, vi } from "vitest";
+import { InMemoryStore } from "../src/store";
+
+describe("InMemoryStore clock handling", () => {
+  test("deducts elapsed time only once on submitMove", () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(1_000_000);
+
+    const store = new InMemoryStore();
+    const created = store.createGame({ mainMinutes: 5, byoSeconds: 30 });
+    const black = store.joinGame(created.gameId, {
+      name: "black",
+      seat: "black",
+      joinToken: created.joinToken,
+    });
+    store.joinGame(created.gameId, {
+      name: "white",
+      seat: "white",
+      joinToken: created.joinToken,
+    });
+
+    const game = store.getGame(created.gameId);
+    expect(game).not.toBeNull();
+    if (!game) {
+      nowSpy.mockRestore();
+      return;
+    }
+
+    game.mainSecondsBlack = 100;
+    game.turn = "black";
+    game.status = "active";
+    game.turnStartedAtMs = 1_000_000;
+    const expectedVersion = game.version;
+
+    nowSpy.mockReturnValue(1_001_500);
+
+    const actor = store.findPlayerByGuestId(created.gameId, black.guestId);
+    expect(actor).not.toBeNull();
+    if (!actor) {
+      nowSpy.mockRestore();
+      return;
+    }
+
+    const updated = store.submitMove(
+      created.gameId,
+      actor,
+      { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },
+      expectedVersion,
+    );
+
+    expect(updated.mainSecondsBlack).toBe(98);
+    nowSpy.mockRestore();
+  });
+});

--- a/server/tests/validationErrors.test.ts
+++ b/server/tests/validationErrors.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import type { AddressInfo } from "node:net";
+import { createApp } from "../src/app";
+
+const app = createApp();
+let baseUrl = "";
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    app.listen(0, () => {
+      const address = app.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    app.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+describe("request validation errors", () => {
+  test("returns 400 when JSON body is malformed", async () => {
+    const response = await fetch(`${baseUrl}/api/games`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBe("INVALID_JSON");
+  });
+
+  test("returns 400 when create payload is null", async () => {
+    const response = await fetch(`${baseUrl}/api/games`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "null",
+    });
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBe("INVALID_CREATE_GAME_PAYLOAD");
+  });
+
+  test("returns 400 when move payload shape is invalid", async () => {
+    const createRes = await fetch(`${baseUrl}/api/games`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mainMinutes: 5, byoSeconds: 30 }),
+    });
+    expect(createRes.status).toBe(201);
+    const created = (await createRes.json()) as { gameId: string; joinToken: string };
+
+    const blackJoinRes = await fetch(`${baseUrl}/api/games/${created.gameId}/join`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "black", seat: "black", joinToken: created.joinToken }),
+    });
+    expect(blackJoinRes.status).toBe(200);
+    const blackJoin = (await blackJoinRes.json()) as { sessionToken: string };
+
+    const whiteJoinRes = await fetch(`${baseUrl}/api/games/${created.gameId}/join`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "white", seat: "white", joinToken: created.joinToken }),
+    });
+    expect(whiteJoinRes.status).toBe(200);
+
+    const snapshotRes = await fetch(`${baseUrl}/api/games/${created.gameId}`);
+    expect(snapshotRes.status).toBe(200);
+    const snapshot = (await snapshotRes.json()) as { version: number };
+
+    const badMoveRes = await fetch(`${baseUrl}/api/games/${created.gameId}/moves`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${blackJoin.sessionToken}`,
+      },
+      body: JSON.stringify({ expectedVersion: snapshot.version, move: {} }),
+    });
+
+    expect(badMoveRes.status).toBe(400);
+    const payload = (await badMoveRes.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBe("INVALID_MOVE_PAYLOAD");
+  });
+});


### PR DESCRIPTION
 - fix/server-hardening-review-findings ブランチを作成し、TDDで修正（先にテスト追加→失敗確認→実装修正→全テスト成功）を実施
  - 着手時の持ち時間二重減算を修正（submitMove 内の重複時間減算を削除）
  - JSONパース失敗を INVALID_JSON の 400 で返すように修正（500 回避）
  - create/join/move の入力バリデーションを unknown ベースの型ガードに強化
  - move: {} や null など不正ペイロードを 400 で返すよう修正
  - レートリミッタに期限切れバケットのクリーンアップ処理を追加（メモリ肥大対策）
  - 追加テスト:
      - server/tests/storeClock.test.ts（時間二重減算防止）
      - server/tests/validationErrors.test.ts（不正JSON/不正payloadの400応答）
      - server/tests/rateLimiter.test.ts（期限切れ掃除と制限動作）