### PR TITLE
PR品質ゲート（test/build）をGitHub Actionsで自動化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI Quality Gate
+
+on:
+  pull_request:
+  push:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Build application
+        run: npm run build

--- a/Agent.md
+++ b/Agent.md
@@ -11,6 +11,8 @@ This repository follows a git-flow style workflow.
 2. `develop`
 - Primary integration branch for ongoing development.
 - All feature branches must be created from `develop`.
+- Direct commits/pushes to `develop` are prohibited.
+- Changes must reach `develop` only via reviewed PR merges from `feature/*` or `fix/*`.
 
 3. `feature/*`
 - Implement one feature per branch.
@@ -24,6 +26,7 @@ This repository follows a git-flow style workflow.
 3. Implement only the scoped feature in that branch.
 4. Open PR from `feature/*` to `develop`.
 5. Merge to `main` only through release process.
+6. Never push commits directly to `develop`.
 
 ## Issue Implementation Protocol (Mandatory)
 

--- a/Agent.md
+++ b/Agent.md
@@ -25,6 +25,19 @@ This repository follows a git-flow style workflow.
 4. Open PR from `feature/*` to `develop`.
 5. Merge to `main` only through release process.
 
+## Issue Implementation Protocol (Mandatory)
+
+1. Handle issues one by one, and create a dedicated branch per issue.
+2. Branch naming should include issue number, e.g. `feature/issue-58-<topic>`.
+3. Before coding, write and confirm concrete requirements for that issue.
+4. Use TDD by default:
+- Write/extend tests first and confirm they fail for the target behavior.
+- Implement the minimum change to make tests pass.
+- Refactor while keeping tests green.
+5. CI-related issues may skip strict TDD where not practical.
+6. After implementation, always run regression tests (`npm test`) and build check (`npm run build`).
+7. Do not batch multiple issues into a single implementation branch.
+
 ## Operational Rules for Agents
 
 1. Never implement new features directly on `main`.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 ﻿# shogi_game
 
 Browser shogi game project.
+[![CI Quality Gate](https://github.com/drumsuko1113/codex_test_creategame/actions/workflows/ci.yml/badge.svg)](https://github.com/drumsuko1113/codex_test_creategame/actions/workflows/ci.yml)
 
 ## Setup
 1. Install dependencies: `npm install`
 2. Start dev server: `npm run dev`
 3. Run tests: `npm run test`
+
+## CI
+- This repository uses GitHub Actions as a quality gate.
+- On every `pull_request` and `push`, CI runs:
+  1. `npm ci`
+  2. `npm run test`
+  3. `npm run build`
 
 ## Structure
 - `app/`: Browser UI (React + TypeScript)

--- a/docs/ops/issue-58-ci-requirements.md
+++ b/docs/ops/issue-58-ci-requirements.md
@@ -1,0 +1,45 @@
+# Issue #58 CI Requirements
+
+## Background
+- Changes currently rely on manual local checks.
+- Regression risk increases without automatic quality gates.
+
+## Goal
+- Run automated quality checks on GitHub for PR and Push.
+- Block merge when test/build fails.
+
+## Scope
+- Add GitHub Actions workflow for CI.
+- Trigger workflow on:
+  - `pull_request`
+  - `push`
+- Execute the following in order:
+  1. `npm ci`
+  2. `npm run test`
+  3. `npm run build`
+- Configure dependency cache for npm to reduce execution time.
+- Document CI policy (or badge) in `README.md`.
+
+## Out of Scope
+- Browser E2E tests.
+- Deployment pipeline.
+- Security scan pipeline.
+
+## Technical Constraints
+- Use repository root as working directory.
+- Use lockfile-based install (`npm ci`) for reproducibility.
+- Workflow must fail immediately if any required step fails.
+
+## Acceptance Criteria
+1. CI runs automatically when PR is opened/updated.
+2. CI runs automatically on push.
+3. CI fails when test or build fails.
+4. README clearly states CI quality gate policy.
+
+## Verification Plan
+1. Static verification:
+  - Workflow YAML syntax is valid.
+  - Trigger/events and steps match requirements.
+2. Runtime verification:
+  - Confirm local `npm run test` and `npm run build` pass before push.
+  - After push/PR, confirm GitHub Actions workflow starts and reports status.


### PR DESCRIPTION
  - CIワークフローを追加
      - ci.yml(workflows\ci.yml)
      - push / pull_request をトリガーに npm ci → npm run test → npm run build を実行
      - Node.js 22 + npmキャッシュ、同一refの古い実行をキャンセルする concurrency を設定
  - CI方針をREADMEに明記し、バッジを追加
  - Issue #58 の要件定義ドキュメントを追加
      - issue-58-ci-requirements.md (docs\ops\issue-58-ci-requirements.md)
  - 運用ルールを強化
      - Agent.md
      - develop への直接 commit/push 禁止（feature/* / fix/* からPR経由のみ）