### PR TITLE
InMemoryStoreを永続ストア（PostgreSQL）に置換

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -48,6 +48,12 @@ This repository follows a git-flow style workflow.
 3. Keep commits small and feature-focused.
 4. Include branch context in status updates when relevant.
 
+## Reporting Rules (Mandatory)
+
+1. Do not include local absolute paths (e.g. `C:\...`) in implementation summaries, PR descriptions, or PR comments.
+2. Always use repository-relative paths (e.g. `server/src/app.ts`).
+3. When sharing change lists for PR text, provide plain relative file paths only.
+
 ## Approval Policy
 
 1. In this repository, agent approval is not required for `git commit`.

--- a/docs/ops/issue-56-persistence-requirements.md
+++ b/docs/ops/issue-56-persistence-requirements.md
@@ -1,0 +1,55 @@
+# Issue #56 永続ストア要件定義
+
+## 背景
+- 現在の `InMemoryStore` はプロセス再起動で対局データが消失する。
+- オンライン対戦継続性を担保するには、ゲーム状態・参加者・棋譜の永続化が必須。
+
+## 目的
+- サーバ状態を PostgreSQL に保存し、再起動後も `create/join/move/resign/snapshot/records` を継続可能にする。
+- 既存 API のレスポンス契約とエラーコードを維持する。
+
+## スコープ
+- `games`, `game_players`, `moves` を使う Repository 層を実装する。
+- ストアを `GameStore` インターフェース化し、`PostgresStore` を追加する。
+- `expectedVersion` 競合制御を DB トランザクション + 更新条件で担保する。
+- `app.ts` / `middleware.ts` を非同期ストア呼び出しに置換する。
+- 起動時に必要な migration を適用できるようにする。
+
+## 非スコープ
+- マルチリージョン構成
+- シャーディング
+- デプロイ基盤の構築（Issue #57）
+
+## 仕様詳細
+1. ストアAPI
+- `createGame`, `joinGame`, `findPlayerBySessionToken`, `findPlayerByGuestId`, `getGame`, `submitMove`, `resign`, `getMoves` を `Promise` ベースに統一する。
+
+2. 永続化
+- `games.state_json` に局面を JSON 保存する。
+- `moves.move_json`, `moves.state_json_after` に指し手と着手後局面を保存する。
+- `joinToken` は平文を返却し、DB にはハッシュ値のみ保存する。
+
+3. 競合制御
+- `submitMove` は対象ゲーム行をロックし、`expectedVersion` 不一致時は `VERSION_CONFLICT` を返す。
+- 同時着手時に先着のみ成功し、後着は 409 に変換されることを維持する。
+
+4. 時計処理
+- 手番経過秒の差分計算は既存ロジックを踏襲する。
+- timeout 発生時は `status=finished`, `resultType=timeout`, `winner` を更新する。
+
+5. 後方互換
+- エラーコード文字列（例: `GAME_NOT_FOUND`, `INVALID_JOIN_TOKEN`, `VERSION_CONFLICT`）は維持する。
+- API入出力スキーマは変更しない。
+
+## 受け入れ条件
+1. `PostgresStore` で `create/join/move/resign/snapshot/records` が動作する。
+2. ストア再インスタンス化後も同一 DB から局面・棋譜を取得できる。
+3. `expectedVersion` 競合時に `VERSION_CONFLICT` が発生する。
+4. 既存テストと追加テストがすべて通過する。
+5. `npm run build` が成功する。
+
+## テスト戦略
+- Red: PostgreSQL 経路の失敗テストを先に追加する。
+- Green: Repository とストア実装を追加してテストを通す。
+- Refactor: ストア抽象化と app 依存注入を整理する。
+- 回帰: `npm test` と `npm run build` を実行する。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,18 @@
       "name": "shogi-game",
       "version": "0.1.0",
       "dependencies": {
+        "pg": "^8.18.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "ws": "^8.19.0"
       },
       "devDependencies": {
+        "@types/pg": "^8.16.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^4.3.2",
+        "pg-mem": "^3.0.13",
         "typescript": "^5.6.2",
         "vite": "^5.4.8",
         "vitest": "^2.1.1"
@@ -53,6 +56,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1164,6 +1168,18 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1177,6 +1193,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1379,6 +1396,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1401,6 +1419,56 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1451,6 +1519,13 @@
         "node": ">= 16"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1493,6 +1568,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
@@ -1500,12 +1615,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1591,6 +1739,23 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1600,6 +1765,111 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -1620,6 +1890,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1631,6 +1921,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/loose-envify": {
@@ -1672,6 +1972,33 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1698,12 +2025,55 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -1720,6 +2090,186 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.11.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
+      "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-mem": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.13.tgz",
+      "integrity": "sha512-ucN2XhP1njQ1XbShLBoK12nK/Jj0iuJnk7S5hXWgf75EbxciUty1rDpeWWVwU5LC4awjihY2UJy2QNbdT8/6lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.2"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-mem/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pg-mem/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pg-pool": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.2.tgz",
+      "integrity": "sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
       }
     },
     "node_modules/picocolors": {
@@ -1758,11 +2308,72 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1791,6 +2402,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/rollup": {
@@ -1857,6 +2478,24 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1872,6 +2511,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -1990,6 +2638,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2169,6 +2818,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,15 +10,18 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "pg": "^8.18.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "ws": "^8.19.0"
   },
   "devDependencies": {
+    "@types/pg": "^8.16.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^4.3.2",
+    "pg-mem": "^3.0.13",
     "typescript": "^5.6.2",
     "vite": "^5.4.8",
     "vitest": "^2.1.1"

--- a/server/db/migrations/002_game_store_persistence_columns.sql
+++ b/server/db/migrations/002_game_store_persistence_columns.sql
@@ -1,0 +1,9 @@
+ALTER TABLE games
+ADD COLUMN IF NOT EXISTS join_token_hash TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE games
+ADD COLUMN IF NOT EXISTS turn_started_at_ms BIGINT NOT NULL DEFAULT 0;
+
+UPDATE games
+SET turn_started_at_ms = (EXTRACT(EPOCH FROM updated_at) * 1000)::BIGINT
+WHERE turn_started_at_ms = 0;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -7,26 +7,27 @@ import { RateLimiter } from "./rateLimiter";
 import { RealtimeHub } from "./realtime";
 import { respond, respondError } from "./respond";
 import { ROUTE_JOIN, ROUTE_MOVE, ROUTE_RECORDS, ROUTE_RESIGN, ROUTE_SNAPSHOT } from "./routePatterns";
-import { InMemoryStore } from "./store";
+import { createDefaultStore, type GameStore } from "./store";
 import type { Player } from "./types";
 import { isMoveRequestBody, isValidCreateGameInput, isValidJoinGameInput } from "./validators";
 
-const store = new InMemoryStore();
-const rateLimiter = new RateLimiter(60_000, 120);
-const realtime = new RealtimeHub();
+type AppOptions = {
+  store?: GameStore;
+};
 
 function getErrorCode(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
-function authenticateActor(
+async function authenticateActor(
   req: IncomingMessage,
   res: ServerResponse,
+  store: GameStore,
   gameId: string,
   ctx: ReturnType<typeof makeRequestContext>,
-): Player | null {
+): Promise<Player | null> {
   try {
-    return requireSessionAuth(req, store, gameId);
+    return await requireSessionAuth(req, store, gameId);
   } catch (error) {
     const code = getErrorCode(error, "UNAUTHORIZED");
     if (code === "UNAUTHORIZED") {
@@ -37,7 +38,13 @@ function authenticateActor(
   }
 }
 
-async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  store: GameStore,
+  rateLimiter: RateLimiter,
+  realtime: RealtimeHub,
+): Promise<void> {
   const ctx = makeRequestContext(req);
 
   if (ctx.path.startsWith("/api/")) {
@@ -60,7 +67,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       return;
     }
 
-    const created = store.createGame(body);
+    const created = await store.createGame(body);
     respond(res, ctx, 201, created, { gameId: created.gameId, event: "game.created" });
     realtime.broadcast(created.gameId, "game.created", created);
     return;
@@ -76,7 +83,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
     }
 
     try {
-      const joined = store.joinGame(gameId, body);
+      const joined = await store.joinGame(gameId, body);
       respond(res, ctx, 200, joined, { gameId, guestId: joined.guestId, event: "game.joined" });
       realtime.broadcast(gameId, "player.joined", joined);
       return;
@@ -101,7 +108,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   const recordsMatch = req.url?.match(ROUTE_RECORDS);
   if (req.method === "GET" && recordsMatch) {
     const gameId = recordsMatch[1];
-    const game = store.getGame(gameId);
+    const game = await store.getGame(gameId);
     if (!game) {
       respondError(res, ctx, 404, "GAME_NOT_FOUND", "Game was not found", { gameId });
       return;
@@ -116,7 +123,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
         status: game.status,
         winner: game.winner,
         resultType: game.resultType,
-        moves: store.getMoves(gameId),
+        moves: await store.getMoves(gameId),
       },
       { gameId, event: "game.records" },
     );
@@ -126,7 +133,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   const getGameMatch = req.url?.match(ROUTE_SNAPSHOT);
   if (req.method === "GET" && getGameMatch) {
     const gameId = getGameMatch[1];
-    const game = store.getGame(gameId);
+    const game = await store.getGame(gameId);
     if (!game) {
       respondError(res, ctx, 404, "GAME_NOT_FOUND", "Game was not found", { gameId });
       return;
@@ -138,7 +145,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   const moveMatch = req.url?.match(ROUTE_MOVE);
   if (req.method === "POST" && moveMatch) {
     const gameId = moveMatch[1];
-    const actor = authenticateActor(req, res, gameId, ctx);
+    const actor = await authenticateActor(req, res, store, gameId, ctx);
     if (!actor) {
       return;
     }
@@ -150,7 +157,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
     }
 
     try {
-      const updated = store.submitMove(gameId, actor, body.move, body.expectedVersion);
+      const updated = await store.submitMove(gameId, actor, body.move, body.expectedVersion);
       respond(res, ctx, 200, updated, { gameId, guestId: actor.guestId, event: "game.moved" });
       realtime.broadcast(gameId, "game.updated", updated);
       return;
@@ -175,13 +182,13 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   const resignMatch = req.url?.match(ROUTE_RESIGN);
   if (req.method === "POST" && resignMatch) {
     const gameId = resignMatch[1];
-    const actor = authenticateActor(req, res, gameId, ctx);
+    const actor = await authenticateActor(req, res, store, gameId, ctx);
     if (!actor) {
       return;
     }
 
     try {
-      const updated = store.resign(gameId, actor);
+      const updated = await store.resign(gameId, actor);
       respond(res, ctx, 200, updated, { gameId, guestId: actor.guestId, event: "game.resigned" });
       realtime.broadcast(gameId, "game.finished", updated);
       return;
@@ -202,9 +209,13 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   respondError(res, ctx, 404, "NOT_FOUND", "Route not found");
 }
 
-export function createApp() {
+export function createApp(options: AppOptions = {}) {
+  const store = options.store ?? createDefaultStore();
+  const rateLimiter = new RateLimiter(60_000, 120);
+  const realtime = new RealtimeHub();
+
   const server = createServer((req, res) => {
-    handleRequest(req, res).catch((error: unknown) => {
+    handleRequest(req, res, store, rateLimiter, realtime).catch((error: unknown) => {
       const ctx = makeRequestContext(req);
       const message = getErrorCode(error, "Internal Server Error");
       if (message === "INVALID_JSON") {
@@ -222,6 +233,22 @@ export function createApp() {
       respondError(res, ctx, 500, "INTERNAL_ERROR", message);
     });
   });
+
   realtime.attach(server);
+  server.on("close", () => {
+    if (!store.close) {
+      return;
+    }
+    store.close().catch((error: unknown) => {
+      log({
+        level: "error",
+        event: "store.close.error",
+        requestId: "server-close",
+        method: "SYSTEM",
+        path: "/",
+        message: getErrorCode(error, "STORE_CLOSE_ERROR"),
+      });
+    });
+  });
   return server;
 }

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from "node:http";
 import { hashToken } from "./auth";
 import { verifyManagedAuthToken } from "./managedAuth";
-import type { InMemoryStore } from "./store";
+import type { GameStore } from "./store";
 import type { Player } from "./types";
 
 function readBearerToken(req: IncomingMessage): string | null {
@@ -17,19 +17,19 @@ function readBearerToken(req: IncomingMessage): string | null {
   return token;
 }
 
-export function requireSessionAuth(req: IncomingMessage, store: InMemoryStore, gameId: string): Player {
+export async function requireSessionAuth(req: IncomingMessage, store: GameStore, gameId: string): Promise<Player> {
   const token = readBearerToken(req);
   if (!token) {
     throw new Error("UNAUTHORIZED");
   }
 
-  const sessionPlayer = store.findPlayerBySessionToken(gameId, hashToken(token));
+  const sessionPlayer = await store.findPlayerBySessionToken(gameId, hashToken(token));
   if (sessionPlayer) {
     return sessionPlayer;
   }
 
   const managed = verifyManagedAuthToken(token);
-  const player = managed ? store.findPlayerByGuestId(gameId, managed.subject) : null;
+  const player = managed ? await store.findPlayerByGuestId(gameId, managed.subject) : null;
   if (!player) {
     throw new Error("UNAUTHORIZED");
   }

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -1,13 +1,135 @@
-﻿import { randomUUID } from "node:crypto";
-import type { Move } from "../../core/src/types";
+import { randomUUID } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Pool } from "pg";
+import type { Move, GameState } from "../../core/src/types";
 import { applyMove } from "../../core/src/applyMove";
 import { createInitialGameState } from "../../core/src/initialPosition";
 import { createSessionToken, hashToken } from "./auth";
 import { issueManagedAuthToken } from "./managedAuth";
 import type { CreateGameInput, Game, JoinGameInput, MoveRecord, Player, Seat } from "./types";
 
+type DbQueryResult<T> = {
+  rows: T[];
+  rowCount: number | null;
+};
+
+type Queryable = {
+  query<T extends Record<string, unknown>>(text: string, params?: readonly unknown[]): Promise<DbQueryResult<T>>;
+};
+
+type TransactionClient = Queryable & {
+  release: () => void;
+};
+
+type PoolLike = Queryable & {
+  connect: () => Promise<TransactionClient>;
+  end?: () => Promise<void>;
+};
+
+type PersistedGame = {
+  id: string;
+  status: Game["status"];
+  turn: Seat;
+  state: GameState;
+  mainSecondsBlack: number;
+  mainSecondsWhite: number;
+  byoSecondsBlack: number;
+  byoSecondsWhite: number;
+  resultType: Game["resultType"] | null;
+  winner: Seat | null;
+  version: number;
+  turnStartedAtMs: number;
+  createdAt: string;
+  updatedAt: string;
+  joinTokenHash: string;
+};
+
+type GameRow = {
+  id: string;
+  status: Game["status"];
+  turn: Seat;
+  state_json: GameState;
+  main_seconds_black: number | string;
+  main_seconds_white: number | string;
+  byo_seconds_black: number | string;
+  byo_seconds_white: number | string;
+  result_type: Game["resultType"] | null;
+  winner: Seat | null;
+  version: number | string;
+  turn_started_at_ms: number | string | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+  join_token_hash: string;
+};
+
+type PlayerRow = {
+  id: string;
+  game_id: string;
+  seat: Seat;
+  guest_id: string;
+  display_name: string;
+  session_token_hash: string;
+  joined_at: string | Date;
+};
+
+type MoveRow = {
+  ply: number | string;
+  actor_seat: Seat;
+  move_json: Move;
+  state_json_after: GameState;
+  created_at: string | Date;
+};
+
+type MaxPlyRow = {
+  max_ply: number | string | null;
+};
+
+export interface GameStore {
+  createGame(input: CreateGameInput): Promise<{ gameId: string; joinToken: string }>;
+  joinGame(gameId: string, input: JoinGameInput): Promise<{
+    guestId: string;
+    sessionToken: string;
+    managedToken: string | null;
+    seat: Seat;
+  }>;
+  findPlayerBySessionToken(gameId: string, tokenHash: string): Promise<Player | null>;
+  findPlayerByGuestId(gameId: string, guestId: string): Promise<Player | null>;
+  getGame(gameId: string): Promise<Game | null>;
+  submitMove(gameId: string, actor: Player, move: Move, expectedVersion: number): Promise<Game>;
+  resign(gameId: string, actor: Player): Promise<Game>;
+  getMoves(gameId: string): Promise<MoveRecord[]>;
+  close?(): Promise<void>;
+}
+
 function toIsoNow(): string {
   return new Date().toISOString();
+}
+
+function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function toNumber(value: number | string | bigint | null | undefined): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function splitSqlStatements(script: string): string[] {
+  return script
+    .split(/;\s*(?:\r?\n|$)/g)
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
 }
 
 function createJoinToken(): string {
@@ -18,55 +140,169 @@ function oppositeSeat(seat: Seat): Seat {
   return seat === "black" ? "white" : "black";
 }
 
-export class InMemoryStore {
+function applyElapsedClock(game: PersistedGame, seat: Seat, nowMs: number): boolean {
+  const elapsedSeconds = Math.ceil(Math.max(0, nowMs - game.turnStartedAtMs) / 1000);
+
+  if (seat === "black") {
+    if (elapsedSeconds <= game.mainSecondsBlack) {
+      game.mainSecondsBlack -= elapsedSeconds;
+      return false;
+    }
+    const overtime = elapsedSeconds - game.mainSecondsBlack;
+    game.mainSecondsBlack = 0;
+    return overtime > game.byoSecondsBlack;
+  }
+
+  if (elapsedSeconds <= game.mainSecondsWhite) {
+    game.mainSecondsWhite -= elapsedSeconds;
+    return false;
+  }
+
+  const overtime = elapsedSeconds - game.mainSecondsWhite;
+  game.mainSecondsWhite = 0;
+  return overtime > game.byoSecondsWhite;
+}
+
+function settleTimeoutIfNeeded(game: PersistedGame, nowMs: number): boolean {
+  if (game.status !== "active") {
+    return false;
+  }
+
+  const timedOut = applyElapsedClock(game, game.turn, nowMs);
+  if (!timedOut) {
+    return false;
+  }
+
+  game.status = "finished";
+  game.resultType = "timeout";
+  game.winner = oppositeSeat(game.turn);
+  game.updatedAt = new Date(nowMs).toISOString();
+  game.version += 1;
+  return true;
+}
+
+function toGame(snapshot: PersistedGame): Game {
+  return {
+    id: snapshot.id,
+    status: snapshot.status,
+    turn: snapshot.turn,
+    state: snapshot.state,
+    mainSecondsBlack: snapshot.mainSecondsBlack,
+    mainSecondsWhite: snapshot.mainSecondsWhite,
+    byoSecondsBlack: snapshot.byoSecondsBlack,
+    byoSecondsWhite: snapshot.byoSecondsWhite,
+    resultType: snapshot.resultType,
+    winner: snapshot.winner,
+    version: snapshot.version,
+    turnStartedAtMs: snapshot.turnStartedAtMs,
+    createdAt: snapshot.createdAt,
+    updatedAt: snapshot.updatedAt,
+  };
+}
+
+function mapGameRow(row: GameRow): PersistedGame {
+  const updatedAt = toIso(row.updated_at);
+  const persistedTurnStartedAtMs = toNumber(row.turn_started_at_ms);
+  const fallbackTurnStartedAtMs = new Date(updatedAt).getTime();
+
+  return {
+    id: row.id,
+    status: row.status,
+    turn: row.turn,
+    state: row.state_json,
+    mainSecondsBlack: toNumber(row.main_seconds_black),
+    mainSecondsWhite: toNumber(row.main_seconds_white),
+    byoSecondsBlack: toNumber(row.byo_seconds_black),
+    byoSecondsWhite: toNumber(row.byo_seconds_white),
+    resultType: row.result_type,
+    winner: row.winner,
+    version: toNumber(row.version),
+    turnStartedAtMs: persistedTurnStartedAtMs > 0 ? persistedTurnStartedAtMs : fallbackTurnStartedAtMs,
+    createdAt: toIso(row.created_at),
+    updatedAt,
+    joinTokenHash: row.join_token_hash,
+  };
+}
+
+function mapPlayerRow(row: PlayerRow): Player {
+  return {
+    id: row.id,
+    gameId: row.game_id,
+    seat: row.seat,
+    guestId: row.guest_id,
+    displayName: row.display_name,
+    sessionTokenHash: row.session_token_hash,
+    joinedAt: toIso(row.joined_at),
+  };
+}
+
+function mapMoveRow(row: MoveRow): MoveRecord {
+  return {
+    ply: toNumber(row.ply),
+    actorSeat: row.actor_seat,
+    move: row.move_json,
+    stateAfter: row.state_json_after,
+    createdAt: toIso(row.created_at),
+  };
+}
+
+let migrationScriptsPromise: Promise<string[]> | null = null;
+
+async function loadMigrationScripts(): Promise<string[]> {
+  const migrationDir = fileURLToPath(new URL("../db/migrations", import.meta.url));
+  const files = (await readdir(migrationDir)).filter((file) => file.endsWith(".sql")).sort();
+  return Promise.all(files.map((file) => readFile(path.join(migrationDir, file), "utf8")));
+}
+
+async function getMigrationScripts(): Promise<string[]> {
+  if (!migrationScriptsPromise) {
+    migrationScriptsPromise = loadMigrationScripts();
+  }
+  return migrationScriptsPromise;
+}
+
+export class InMemoryStore implements GameStore {
   private readonly games = new Map<string, Game>();
   private readonly joinTokens = new Map<string, string>();
   private readonly playersByGame = new Map<string, Player[]>();
   private readonly movesByGame = new Map<string, MoveRecord[]>();
 
-  private applyElapsedClock(game: Game, seat: Seat, nowMs: number): boolean {
-    const elapsedSeconds = Math.ceil(Math.max(0, nowMs - game.turnStartedAtMs) / 1000);
-
-    if (seat === "black") {
-      if (elapsedSeconds <= game.mainSecondsBlack) {
-        game.mainSecondsBlack -= elapsedSeconds;
-        return false;
-      }
-      const overtime = elapsedSeconds - game.mainSecondsBlack;
-      game.mainSecondsBlack = 0;
-      return overtime > game.byoSecondsBlack;
-    }
-
-    if (elapsedSeconds <= game.mainSecondsWhite) {
-      game.mainSecondsWhite -= elapsedSeconds;
-      return false;
-    }
-    const overtime = elapsedSeconds - game.mainSecondsWhite;
-    game.mainSecondsWhite = 0;
-    return overtime > game.byoSecondsWhite;
-  }
-
   private settleTimeoutIfNeeded(game: Game): void {
-    if (game.status !== "active") {
-      return;
-    }
+    const snapshot: PersistedGame = {
+      id: game.id,
+      status: game.status,
+      turn: game.turn,
+      state: game.state,
+      mainSecondsBlack: game.mainSecondsBlack,
+      mainSecondsWhite: game.mainSecondsWhite,
+      byoSecondsBlack: game.byoSecondsBlack,
+      byoSecondsWhite: game.byoSecondsWhite,
+      resultType: game.resultType,
+      winner: game.winner,
+      version: game.version,
+      turnStartedAtMs: game.turnStartedAtMs,
+      createdAt: game.createdAt,
+      updatedAt: game.updatedAt,
+      joinTokenHash: "",
+    };
 
-    const nowMs = Date.now();
-    const timedOut = this.applyElapsedClock(game, game.turn, nowMs);
-    if (!timedOut) {
-      return;
-    }
+    const changed = settleTimeoutIfNeeded(snapshot, Date.now());
 
-    game.status = "finished";
-    game.resultType = "timeout";
-    game.winner = oppositeSeat(game.turn);
-    game.updatedAt = toIsoNow();
-    game.version += 1;
+    game.mainSecondsBlack = snapshot.mainSecondsBlack;
+    game.mainSecondsWhite = snapshot.mainSecondsWhite;
+    if (changed) {
+      game.status = snapshot.status;
+      game.resultType = snapshot.resultType;
+      game.winner = snapshot.winner;
+      game.updatedAt = snapshot.updatedAt;
+      game.version = snapshot.version;
+    }
   }
 
-  createGame(input: CreateGameInput): { gameId: string; joinToken: string } {
+  async createGame(input: CreateGameInput): Promise<{ gameId: string; joinToken: string }> {
     const gameId = randomUUID();
-    const now = toIsoNow();
+    const nowMs = Date.now();
+    const nowIso = new Date(nowMs).toISOString();
 
     this.games.set(gameId, {
       id: gameId,
@@ -80,24 +316,25 @@ export class InMemoryStore {
       resultType: null,
       winner: null,
       version: 1,
-      turnStartedAtMs: Date.now(),
-      createdAt: now,
-      updatedAt: now,
+      turnStartedAtMs: nowMs,
+      createdAt: nowIso,
+      updatedAt: nowIso,
     });
 
     const joinToken = createJoinToken();
     this.joinTokens.set(gameId, joinToken);
     this.playersByGame.set(gameId, []);
     this.movesByGame.set(gameId, []);
+
     return { gameId, joinToken };
   }
 
-  joinGame(gameId: string, input: JoinGameInput): {
+  async joinGame(gameId: string, input: JoinGameInput): Promise<{
     guestId: string;
     sessionToken: string;
     managedToken: string | null;
     seat: Seat;
-  } {
+  }> {
     const game = this.games.get(gameId);
     if (!game) {
       throw new Error("GAME_NOT_FOUND");
@@ -123,7 +360,8 @@ export class InMemoryStore {
 
     const sessionToken = createSessionToken();
     const guestId = randomUUID();
-    const player: Player = {
+
+    players.push({
       id: randomUUID(),
       gameId,
       seat: input.seat,
@@ -131,9 +369,8 @@ export class InMemoryStore {
       displayName: input.name.trim(),
       sessionTokenHash: hashToken(sessionToken),
       joinedAt: toIsoNow(),
-    };
+    });
 
-    players.push(player);
     game.status = players.length === 2 ? "active" : "waiting";
     if (game.status === "active") {
       game.turnStartedAtMs = Date.now();
@@ -149,7 +386,7 @@ export class InMemoryStore {
     };
   }
 
-  findPlayerBySessionToken(gameId: string, tokenHash: string): Player | null {
+  async findPlayerBySessionToken(gameId: string, tokenHash: string): Promise<Player | null> {
     const players = this.playersByGame.get(gameId);
     if (!players) {
       return null;
@@ -157,7 +394,7 @@ export class InMemoryStore {
     return players.find((player) => player.sessionTokenHash === tokenHash) ?? null;
   }
 
-  findPlayerByGuestId(gameId: string, guestId: string): Player | null {
+  async findPlayerByGuestId(gameId: string, guestId: string): Promise<Player | null> {
     const players = this.playersByGame.get(gameId);
     if (!players) {
       return null;
@@ -165,7 +402,7 @@ export class InMemoryStore {
     return players.find((player) => player.guestId === guestId) ?? null;
   }
 
-  getGame(gameId: string): Game | null {
+  async getGame(gameId: string): Promise<Game | null> {
     const game = this.games.get(gameId) ?? null;
     if (!game) {
       return null;
@@ -174,7 +411,7 @@ export class InMemoryStore {
     return game;
   }
 
-  submitMove(gameId: string, actor: Player, move: Move, expectedVersion: number): Game {
+  async submitMove(gameId: string, actor: Player, move: Move, expectedVersion: number): Promise<Game> {
     const game = this.games.get(gameId);
     if (!game) {
       throw new Error("GAME_NOT_FOUND");
@@ -216,7 +453,7 @@ export class InMemoryStore {
     return game;
   }
 
-  resign(gameId: string, actor: Player): Game {
+  async resign(gameId: string, actor: Player): Promise<Game> {
     const game = this.games.get(gameId);
     if (!game) {
       throw new Error("GAME_NOT_FOUND");
@@ -233,10 +470,419 @@ export class InMemoryStore {
     game.winner = oppositeSeat(actor.seat);
     game.updatedAt = toIsoNow();
     game.version += 1;
+
     return game;
   }
 
-  getMoves(gameId: string): MoveRecord[] {
+  async getMoves(gameId: string): Promise<MoveRecord[]> {
     return this.movesByGame.get(gameId) ?? [];
   }
+}
+
+export class PostgresStore implements GameStore {
+  private initPromise: Promise<void> | null = null;
+
+  constructor(private readonly pool: PoolLike) {}
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.runMigrations().catch((error: unknown) => {
+        this.initPromise = null;
+        throw error;
+      });
+    }
+    await this.initPromise;
+  }
+
+  private async runMigrations(): Promise<void> {
+    const scripts = await getMigrationScripts();
+    for (const script of scripts) {
+      const statements = splitSqlStatements(script);
+      for (const statement of statements) {
+        await this.pool.query(statement);
+      }
+    }
+  }
+
+  private async withTransaction<T>(callback: (client: TransactionClient) => Promise<T>): Promise<T> {
+    await this.ensureInitialized();
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await callback(client);
+      await client.query("COMMIT");
+      return result;
+    } catch (error) {
+      try {
+        await client.query("ROLLBACK");
+      } catch {
+        // Ignore rollback errors and preserve the original error.
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async lockGame(client: Queryable, gameId: string): Promise<PersistedGame | null> {
+    const result = await client.query<GameRow>(
+      `SELECT
+         id,
+         status,
+         turn,
+         state_json,
+         main_seconds_black,
+         main_seconds_white,
+         byo_seconds_black,
+         byo_seconds_white,
+         result_type,
+         winner,
+         version,
+         turn_started_at_ms,
+         created_at,
+         updated_at,
+         join_token_hash
+       FROM games
+       WHERE id = $1
+       FOR UPDATE`,
+      [gameId],
+    );
+
+    if (!result.rowCount) {
+      return null;
+    }
+
+    return mapGameRow(result.rows[0]);
+  }
+
+  private async updateGame(client: Queryable, game: PersistedGame, previousVersion: number): Promise<void> {
+    const result = await client.query(
+      `UPDATE games
+       SET
+         status = $2,
+         turn = $3,
+         state_json = $4::jsonb,
+         main_seconds_black = $5,
+         main_seconds_white = $6,
+         byo_seconds_black = $7,
+         byo_seconds_white = $8,
+         result_type = $9,
+         winner = $10,
+         version = $11,
+         turn_started_at_ms = $12,
+         updated_at = $13
+       WHERE id = $1 AND version = $14`,
+      [
+        game.id,
+        game.status,
+        game.turn,
+        JSON.stringify(game.state),
+        game.mainSecondsBlack,
+        game.mainSecondsWhite,
+        game.byoSecondsBlack,
+        game.byoSecondsWhite,
+        game.resultType,
+        game.winner,
+        game.version,
+        game.turnStartedAtMs,
+        game.updatedAt,
+        previousVersion,
+      ],
+    );
+
+    if (!result.rowCount) {
+      throw new Error("VERSION_CONFLICT");
+    }
+  }
+
+  async createGame(input: CreateGameInput): Promise<{ gameId: string; joinToken: string }> {
+    await this.ensureInitialized();
+    const gameId = randomUUID();
+    const joinToken = createJoinToken();
+    const nowMs = Date.now();
+    const nowIso = new Date(nowMs).toISOString();
+
+    await this.pool.query(
+      `INSERT INTO games (
+         id,
+         status,
+         turn,
+         state_json,
+         main_seconds_black,
+         main_seconds_white,
+         byo_seconds_black,
+         byo_seconds_white,
+         result_type,
+         winner,
+         version,
+         join_token_hash,
+         turn_started_at_ms,
+         created_at,
+         updated_at
+       ) VALUES (
+         $1, 'waiting', 'black', $2::jsonb, $3, $3, $4, $4, NULL, NULL, 1, $5, $6, $7, $7
+       )`,
+      [
+        gameId,
+        JSON.stringify(createInitialGameState()),
+        input.mainMinutes * 60,
+        input.byoSeconds,
+        hashToken(joinToken),
+        nowMs,
+        nowIso,
+      ],
+    );
+
+    return { gameId, joinToken };
+  }
+
+  async joinGame(gameId: string, input: JoinGameInput): Promise<{
+    guestId: string;
+    sessionToken: string;
+    managedToken: string | null;
+    seat: Seat;
+  }> {
+    return this.withTransaction(async (client) => {
+      const game = await this.lockGame(client, gameId);
+      if (!game) {
+        throw new Error("GAME_NOT_FOUND");
+      }
+
+      if (game.joinTokenHash !== hashToken(input.joinToken)) {
+        throw new Error("INVALID_JOIN_TOKEN");
+      }
+
+      const playersResult = await client.query<{ seat: Seat }>(
+        `SELECT seat
+         FROM game_players
+         WHERE game_id = $1
+         FOR UPDATE`,
+        [gameId],
+      );
+
+      const seats = playersResult.rows.map((row) => row.seat);
+      if (seats.length >= 2) {
+        throw new Error("GAME_IS_FULL");
+      }
+      if (seats.includes(input.seat)) {
+        throw new Error("SEAT_ALREADY_TAKEN");
+      }
+
+      const sessionToken = createSessionToken();
+      const guestId = randomUUID();
+      const joinedAt = toIsoNow();
+
+      await client.query(
+        `INSERT INTO game_players (
+           id,
+           game_id,
+           seat,
+           guest_id,
+           display_name,
+           session_token_hash,
+           joined_at
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [randomUUID(), gameId, input.seat, guestId, input.name.trim(), hashToken(sessionToken), joinedAt],
+      );
+
+      const nowMs = Date.now();
+      const nowIso = new Date(nowMs).toISOString();
+      game.status = seats.length + 1 === 2 ? "active" : "waiting";
+      game.updatedAt = nowIso;
+      game.version += 1;
+      if (game.status === "active") {
+        game.turnStartedAtMs = nowMs;
+      }
+
+      await this.updateGame(client, game, game.version - 1);
+
+      return {
+        guestId,
+        sessionToken,
+        managedToken: issueManagedAuthToken(guestId),
+        seat: input.seat,
+      };
+    });
+  }
+
+  async findPlayerBySessionToken(gameId: string, tokenHash: string): Promise<Player | null> {
+    await this.ensureInitialized();
+    const result = await this.pool.query<PlayerRow>(
+      `SELECT
+         id,
+         game_id,
+         seat,
+         guest_id,
+         display_name,
+         session_token_hash,
+         joined_at
+       FROM game_players
+       WHERE game_id = $1 AND session_token_hash = $2
+       LIMIT 1`,
+      [gameId, tokenHash],
+    );
+    if (!result.rowCount) {
+      return null;
+    }
+    return mapPlayerRow(result.rows[0]);
+  }
+
+  async findPlayerByGuestId(gameId: string, guestId: string): Promise<Player | null> {
+    await this.ensureInitialized();
+    const result = await this.pool.query<PlayerRow>(
+      `SELECT
+         id,
+         game_id,
+         seat,
+         guest_id,
+         display_name,
+         session_token_hash,
+         joined_at
+       FROM game_players
+       WHERE game_id = $1 AND guest_id = $2
+       LIMIT 1`,
+      [gameId, guestId],
+    );
+    if (!result.rowCount) {
+      return null;
+    }
+    return mapPlayerRow(result.rows[0]);
+  }
+
+  async getGame(gameId: string): Promise<Game | null> {
+    return this.withTransaction(async (client) => {
+      const game = await this.lockGame(client, gameId);
+      if (!game) {
+        return null;
+      }
+
+      const timedOut = settleTimeoutIfNeeded(game, Date.now());
+      if (timedOut) {
+        await this.updateGame(client, game, game.version - 1);
+      }
+
+      return toGame(game);
+    });
+  }
+
+  async submitMove(gameId: string, actor: Player, move: Move, expectedVersion: number): Promise<Game> {
+    return this.withTransaction(async (client) => {
+      const game = await this.lockGame(client, gameId);
+      if (!game) {
+        throw new Error("GAME_NOT_FOUND");
+      }
+
+      const timedOut = settleTimeoutIfNeeded(game, Date.now());
+      if (timedOut) {
+        await this.updateGame(client, game, game.version - 1);
+      }
+
+      if (expectedVersion !== game.version) {
+        throw new Error("VERSION_CONFLICT");
+      }
+      if (game.status !== "active") {
+        throw new Error("GAME_NOT_ACTIVE");
+      }
+      if (actor.seat !== game.turn) {
+        throw new Error("NOT_YOUR_TURN");
+      }
+
+      const result = applyMove(game.state, move);
+      if (!result.ok) {
+        throw new Error(`ILLEGAL_MOVE:${result.reason}`);
+      }
+
+      const previousVersion = game.version;
+      game.state = result.value;
+      game.turn = result.value.turn;
+      game.turnStartedAtMs = Date.now();
+      game.updatedAt = toIsoNow();
+      game.version += 1;
+
+      await this.updateGame(client, game, previousVersion);
+
+      const maxPlyResult = await client.query<MaxPlyRow>(
+        `SELECT COALESCE(MAX(ply), 0) AS max_ply
+         FROM moves
+         WHERE game_id = $1`,
+        [gameId],
+      );
+      const nextPly = toNumber(maxPlyResult.rows[0]?.max_ply) + 1;
+
+      await client.query(
+        `INSERT INTO moves (
+           game_id,
+           ply,
+           actor_seat,
+           move_json,
+           state_json_after,
+           created_at
+         ) VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6)`,
+        [gameId, nextPly, actor.seat, JSON.stringify(move), JSON.stringify(result.value), toIsoNow()],
+      );
+
+      return toGame(game);
+    });
+  }
+
+  async resign(gameId: string, actor: Player): Promise<Game> {
+    return this.withTransaction(async (client) => {
+      const game = await this.lockGame(client, gameId);
+      if (!game) {
+        throw new Error("GAME_NOT_FOUND");
+      }
+
+      const timedOut = settleTimeoutIfNeeded(game, Date.now());
+      if (timedOut) {
+        await this.updateGame(client, game, game.version - 1);
+      }
+
+      if (game.status === "finished") {
+        throw new Error("GAME_ALREADY_FINISHED");
+      }
+
+      const previousVersion = game.version;
+      game.status = "finished";
+      game.resultType = "resign";
+      game.winner = oppositeSeat(actor.seat);
+      game.updatedAt = toIsoNow();
+      game.version += 1;
+
+      await this.updateGame(client, game, previousVersion);
+      return toGame(game);
+    });
+  }
+
+  async getMoves(gameId: string): Promise<MoveRecord[]> {
+    await this.ensureInitialized();
+    const result = await this.pool.query<MoveRow>(
+      `SELECT
+         ply,
+         actor_seat,
+         move_json,
+         state_json_after,
+         created_at
+       FROM moves
+       WHERE game_id = $1
+       ORDER BY ply ASC`,
+      [gameId],
+    );
+
+    return result.rows.map(mapMoveRow);
+  }
+
+  async close(): Promise<void> {
+    if (this.pool.end) {
+      await this.pool.end();
+    }
+  }
+}
+
+export function createDefaultStore(): GameStore {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    return new InMemoryStore();
+  }
+
+  return new PostgresStore(new Pool({ connectionString: databaseUrl }));
 }

--- a/server/tests/onlineFlow.test.ts
+++ b/server/tests/onlineFlow.test.ts
@@ -79,4 +79,62 @@ describe("online match backend flow", () => {
     expect(resigned.winner).toBe("white");
     expect(resigned.resultType).toBe("resign");
   });
+
+  test("returns 409 with VERSION_CONFLICT on stale expectedVersion", async () => {
+    const createRes = await fetch(`${baseUrl}/api/games`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mainMinutes: 5, byoSeconds: 30 }),
+    });
+    expect(createRes.status).toBe(201);
+    const created = (await createRes.json()) as { gameId: string; joinToken: string };
+
+    const blackJoinRes = await fetch(`${baseUrl}/api/games/${created.gameId}/join`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "black", seat: "black", joinToken: created.joinToken }),
+    });
+    expect(blackJoinRes.status).toBe(200);
+    const blackJoin = (await blackJoinRes.json()) as { sessionToken: string };
+
+    const whiteJoinRes = await fetch(`${baseUrl}/api/games/${created.gameId}/join`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "white", seat: "white", joinToken: created.joinToken }),
+    });
+    expect(whiteJoinRes.status).toBe(200);
+
+    const snapshotRes = await fetch(`${baseUrl}/api/games/${created.gameId}`);
+    expect(snapshotRes.status).toBe(200);
+    const snapshot = (await snapshotRes.json()) as { version: number };
+
+    const moveRes = await fetch(`${baseUrl}/api/games/${created.gameId}/moves`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${blackJoin.sessionToken}`,
+      },
+      body: JSON.stringify({
+        expectedVersion: snapshot.version,
+        move: { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },
+      }),
+    });
+    expect(moveRes.status).toBe(200);
+
+    const staleMoveRes = await fetch(`${baseUrl}/api/games/${created.gameId}/moves`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${blackJoin.sessionToken}`,
+      },
+      body: JSON.stringify({
+        expectedVersion: snapshot.version,
+        move: { from: { x: 0, y: 5 }, to: { x: 0, y: 4 } },
+      }),
+    });
+
+    expect(staleMoveRes.status).toBe(409);
+    const payload = (await staleMoveRes.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBe("VERSION_CONFLICT");
+  });
 });

--- a/server/tests/postgresStore.test.ts
+++ b/server/tests/postgresStore.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, describe, expect, test } from "vitest";
+import { newDb } from "pg-mem";
+import { PostgresStore } from "../src/store";
+
+const db = newDb({ autoCreateForeignKeyIndices: true, noAstCoverageCheck: true });
+const { Pool } = db.adapters.createPg();
+const pool = new Pool();
+
+afterAll(async () => {
+  await pool.end();
+});
+
+describe("PostgresStore", () => {
+  test("persists game state and move records across store re-instantiation", async () => {
+    const store1 = new PostgresStore(pool);
+    const created = await store1.createGame({ mainMinutes: 5, byoSeconds: 30 });
+
+    const black = await store1.joinGame(created.gameId, {
+      name: "black",
+      seat: "black",
+      joinToken: created.joinToken,
+    });
+    await store1.joinGame(created.gameId, {
+      name: "white",
+      seat: "white",
+      joinToken: created.joinToken,
+    });
+
+    const snapshot = await store1.getGame(created.gameId);
+    expect(snapshot).not.toBeNull();
+    if (!snapshot) {
+      return;
+    }
+
+    const actor = await store1.findPlayerByGuestId(created.gameId, black.guestId);
+    expect(actor).not.toBeNull();
+    if (!actor) {
+      return;
+    }
+
+    await store1.submitMove(
+      created.gameId,
+      actor,
+      { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },
+      snapshot.version,
+    );
+
+    const store2 = new PostgresStore(pool);
+    const restored = await store2.getGame(created.gameId);
+    expect(restored).not.toBeNull();
+    expect(restored?.version).toBe(snapshot.version + 1);
+
+    const records = await store2.getMoves(created.gameId);
+    expect(records).toHaveLength(1);
+    expect(records[0]?.ply).toBe(1);
+  });
+
+  test("throws VERSION_CONFLICT when expectedVersion is stale", async () => {
+    const store = new PostgresStore(pool);
+    const created = await store.createGame({ mainMinutes: 5, byoSeconds: 30 });
+    const black = await store.joinGame(created.gameId, {
+      name: "black",
+      seat: "black",
+      joinToken: created.joinToken,
+    });
+    await store.joinGame(created.gameId, {
+      name: "white",
+      seat: "white",
+      joinToken: created.joinToken,
+    });
+
+    const game = await store.getGame(created.gameId);
+    expect(game).not.toBeNull();
+    if (!game) {
+      return;
+    }
+
+    const actor = await store.findPlayerByGuestId(created.gameId, black.guestId);
+    expect(actor).not.toBeNull();
+    if (!actor) {
+      return;
+    }
+
+    await store.submitMove(
+      created.gameId,
+      actor,
+      { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },
+      game.version,
+    );
+
+    await expect(
+      store.submitMove(
+        created.gameId,
+        actor,
+        { from: { x: 0, y: 5 }, to: { x: 0, y: 4 } },
+        game.version,
+      ),
+    ).rejects.toThrow("VERSION_CONFLICT");
+  });
+});

--- a/server/tests/storeClock.test.ts
+++ b/server/tests/storeClock.test.ts
@@ -2,24 +2,24 @@ import { describe, expect, test, vi } from "vitest";
 import { InMemoryStore } from "../src/store";
 
 describe("InMemoryStore clock handling", () => {
-  test("deducts elapsed time only once on submitMove", () => {
+  test("deducts elapsed time only once on submitMove", async () => {
     const nowSpy = vi.spyOn(Date, "now");
     nowSpy.mockReturnValue(1_000_000);
 
     const store = new InMemoryStore();
-    const created = store.createGame({ mainMinutes: 5, byoSeconds: 30 });
-    const black = store.joinGame(created.gameId, {
+    const created = await store.createGame({ mainMinutes: 5, byoSeconds: 30 });
+    const black = await store.joinGame(created.gameId, {
       name: "black",
       seat: "black",
       joinToken: created.joinToken,
     });
-    store.joinGame(created.gameId, {
+    await store.joinGame(created.gameId, {
       name: "white",
       seat: "white",
       joinToken: created.joinToken,
     });
 
-    const game = store.getGame(created.gameId);
+    const game = await store.getGame(created.gameId);
     expect(game).not.toBeNull();
     if (!game) {
       nowSpy.mockRestore();
@@ -34,14 +34,14 @@ describe("InMemoryStore clock handling", () => {
 
     nowSpy.mockReturnValue(1_001_500);
 
-    const actor = store.findPlayerByGuestId(created.gameId, black.guestId);
+    const actor = await store.findPlayerByGuestId(created.gameId, black.guestId);
     expect(actor).not.toBeNull();
     if (!actor) {
       nowSpy.mockRestore();
       return;
     }
 
-    const updated = store.submitMove(
+    const updated = await store.submitMove(
       created.gameId,
       actor,
       { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },


### PR DESCRIPTION

  - 要件定義を追加
      - docs/ops/issue-56-persistence-requirements.md
  - ストア抽象化とPostgreSQL実装を追加（非同期化、トランザクション、version競合制御）
      - server/src/store.ts
  - アプリ本体を新しいストアインターフェースへ対応
      - server/src/app.ts
      - server/src/middleware.ts
  - 永続化向けマイグレーションを追加
      - server/db/migrations/002_game_store_persistence_columns.sql
  - テスト追加/更新
      - server/tests/postgresStore.test.ts（永続化・再インスタンス化・VERSION_CONFLICT）
      - server/tests/onlineFlow.test.ts（APIで409/VERSION_CONFLICTの維持）
      - server/tests/storeClock.test.ts（非同期化対応）
  - 依存追加
      - package.json, package-lock.json（pg, pg-mem, @types/pg）
