### PR TITLE
追加機能実装後の全体リファクタリング(2)

### DIFF
--- a/app/src/online/gameApi.ts
+++ b/app/src/online/gameApi.ts
@@ -76,6 +76,8 @@ type ErrorPayload = {
   };
 };
 
+type ApiHeaders = Record<string, string>;
+
 export class ApiClientError extends Error {
   constructor(
     public readonly status: number,
@@ -96,6 +98,23 @@ function normalizeBaseUrl(baseUrl?: string): string {
 function buildApiUrl(path: string, baseUrl?: string): string {
   const normalized = normalizeBaseUrl(baseUrl);
   return normalized ? `${normalized}${path}` : path;
+}
+
+function requestApiJson<T>(path: string, baseUrl?: string, init?: RequestInit): Promise<T> {
+  return requestJson<T>(buildApiUrl(path, baseUrl), init);
+}
+
+function buildAuthHeaders(sessionToken: string): ApiHeaders {
+  return {
+    authorization: `Bearer ${sessionToken}`,
+  };
+}
+
+function buildJsonHeaders(headers?: ApiHeaders): ApiHeaders {
+  return {
+    "content-type": "application/json",
+    ...(headers ?? {}),
+  };
 }
 
 async function parseJsonSafely(response: Response): Promise<unknown> {
@@ -131,17 +150,17 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
 }
 
 export async function createGame(input: CreateGameRequest, baseUrl?: string): Promise<CreateGameResponse> {
-  return requestJson<CreateGameResponse>(buildApiUrl("/api/games", baseUrl), {
+  return requestApiJson<CreateGameResponse>("/api/games", baseUrl, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: buildJsonHeaders(),
     body: JSON.stringify(input),
   });
 }
 
 export async function joinGame(input: JoinGameRequest, baseUrl?: string): Promise<JoinGameResponse> {
-  return requestJson<JoinGameResponse>(buildApiUrl(`/api/games/${input.gameId}/join`, baseUrl), {
+  return requestApiJson<JoinGameResponse>(`/api/games/${input.gameId}/join`, baseUrl, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: buildJsonHeaders(),
     body: JSON.stringify({
       name: input.name,
       seat: input.seat,
@@ -151,24 +170,19 @@ export async function joinGame(input: JoinGameRequest, baseUrl?: string): Promis
 }
 
 export async function getGameSnapshot(gameId: string, baseUrl?: string): Promise<GameSnapshot> {
-  return requestJson<GameSnapshot>(buildApiUrl(`/api/games/${gameId}`, baseUrl));
+  return requestApiJson<GameSnapshot>(`/api/games/${gameId}`, baseUrl);
 }
 
 export async function getSessionPlayer(input: GetSessionPlayerRequest, baseUrl?: string): Promise<SessionPlayerResponse> {
-  return requestJson<SessionPlayerResponse>(buildApiUrl(`/api/games/${input.gameId}/me`, baseUrl), {
-    headers: {
-      authorization: `Bearer ${input.sessionToken}`,
-    },
+  return requestApiJson<SessionPlayerResponse>(`/api/games/${input.gameId}/me`, baseUrl, {
+    headers: buildAuthHeaders(input.sessionToken),
   });
 }
 
 export async function submitMove(input: SubmitMoveRequest, baseUrl?: string): Promise<GameSnapshot> {
-  return requestJson<GameSnapshot>(buildApiUrl(`/api/games/${input.gameId}/moves`, baseUrl), {
+  return requestApiJson<GameSnapshot>(`/api/games/${input.gameId}/moves`, baseUrl, {
     method: "POST",
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${input.sessionToken}`,
-    },
+    headers: buildJsonHeaders(buildAuthHeaders(input.sessionToken)),
     body: JSON.stringify({
       expectedVersion: input.expectedVersion,
       move: input.move,
@@ -177,10 +191,8 @@ export async function submitMove(input: SubmitMoveRequest, baseUrl?: string): Pr
 }
 
 export async function resignGame(input: ResignGameRequest, baseUrl?: string): Promise<GameSnapshot> {
-  return requestJson<GameSnapshot>(buildApiUrl(`/api/games/${input.gameId}/resign`, baseUrl), {
+  return requestApiJson<GameSnapshot>(`/api/games/${input.gameId}/resign`, baseUrl, {
     method: "POST",
-    headers: {
-      authorization: `Bearer ${input.sessionToken}`,
-    },
+    headers: buildAuthHeaders(input.sessionToken),
   });
 }

--- a/app/tests/gameApi.test.ts
+++ b/app/tests/gameApi.test.ts
@@ -134,6 +134,38 @@ describe("gameApi", () => {
     expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:3000/api/games/game-1", undefined);
   });
 
+  test("normalizes baseUrl when trailing slash is provided", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          id: "game-1",
+          status: "active",
+          turn: "black",
+          state: { board: [], hands: { black: {}, white: {} }, turn: "black" },
+          mainSecondsBlack: 300,
+          mainSecondsWhite: 300,
+          byoSecondsBlack: 30,
+          byoSecondsWhite: 30,
+          resultType: null,
+          winner: null,
+          version: 2,
+          turnStartedAtMs: 1000,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:10.000Z",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await getGameSnapshot("game-1", "http://127.0.0.1:3000/");
+
+    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:3000/api/games/game-1", undefined);
+  });
+
   test("submitMove sends expectedVersion and authorization header", async () => {
     const fetchMock = vi.fn(async () =>
       new Response(

--- a/app/tests/moveText.test.ts
+++ b/app/tests/moveText.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { createInitialGameState } from "../../core/src/initialPosition";
+import { formatMoveText, oppositeColor, sideLabel, winnerLabel } from "../src/game/moveText";
+
+describe("moveText helpers", () => {
+  test("oppositeColor flips seat color", () => {
+    expect(oppositeColor("black")).toBe("white");
+    expect(oppositeColor("white")).toBe("black");
+  });
+
+  test("sideLabel and winnerLabel return non-empty labels per side", () => {
+    const blackSide = sideLabel("black");
+    const whiteSide = sideLabel("white");
+    const blackWinner = winnerLabel("black");
+    const whiteWinner = winnerLabel("white");
+
+    expect(blackSide.length).toBeGreaterThan(0);
+    expect(whiteSide.length).toBeGreaterThan(0);
+    expect(blackWinner.length).toBeGreaterThan(0);
+    expect(whiteWinner.length).toBeGreaterThan(0);
+    expect(blackSide).not.toBe(whiteSide);
+    expect(blackWinner).not.toBe(whiteWinner);
+  });
+
+  test("formatMoveText includes source coordinates for board moves", () => {
+    const state = createInitialGameState();
+    const text = formatMoveText(state, { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } }, null);
+
+    expect(text).toContain("(");
+    expect(text).toContain(")");
+  });
+
+  test("formatMoveText for drops omits source coordinate suffix", () => {
+    const state = createInitialGameState();
+    const text = formatMoveText(state, { drop: "pawn", to: { x: 4, y: 4 } }, null);
+
+    expect(text).not.toContain("(");
+    expect(text).not.toContain(")");
+  });
+});

--- a/app/tests/position.test.ts
+++ b/app/tests/position.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+import { isSamePosition, positionToKey } from "../src/game/position";
+
+describe("position helpers", () => {
+  test("positionToKey creates stable coordinate key", () => {
+    expect(positionToKey({ x: 0, y: 0 })).toBe("0:0");
+    expect(positionToKey({ x: 8, y: 8 })).toBe("8:8");
+  });
+
+  test("isSamePosition compares both x and y", () => {
+    expect(isSamePosition({ x: 1, y: 2 }, { x: 1, y: 2 })).toBe(true);
+    expect(isSamePosition({ x: 1, y: 2 }, { x: 2, y: 2 })).toBe(false);
+    expect(isSamePosition({ x: 1, y: 2 }, { x: 1, y: 3 })).toBe(false);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -15,9 +15,67 @@ type AppOptions = {
   store?: GameStore;
 };
 
+type ErrorRule = {
+  match: (code: string) => boolean;
+  statusCode: number;
+  message: string | ((code: string) => string);
+  responseCode?: string;
+};
+
 function getErrorCode(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
+
+function exactCode(code: string): (value: string) => boolean {
+  return (value) => value === code;
+}
+
+function prefixCode(prefix: string): (value: string) => boolean {
+  return (value) => value.startsWith(prefix);
+}
+
+function respondIfMappedError(
+  res: ServerResponse,
+  ctx: ReturnType<typeof makeRequestContext>,
+  code: string,
+  meta: { gameId: string; guestId?: string },
+  rules: readonly ErrorRule[],
+): boolean {
+  const matched = rules.find((rule) => rule.match(code));
+  if (!matched) {
+    return false;
+  }
+
+  respondError(
+    res,
+    ctx,
+    matched.statusCode,
+    matched.responseCode ?? code,
+    typeof matched.message === "function" ? matched.message(code) : matched.message,
+    { gameId: meta.gameId, guestId: meta.guestId },
+  );
+  return true;
+}
+
+const JOIN_ERROR_RULES: readonly ErrorRule[] = [
+  { match: exactCode("GAME_NOT_FOUND"), statusCode: 404, message: "Game was not found" },
+  { match: exactCode("INVALID_JOIN_TOKEN"), statusCode: 401, message: "Join token is invalid" },
+  { match: exactCode("GAME_IS_FULL"), statusCode: 409, message: "Seat is unavailable" },
+  { match: exactCode("SEAT_ALREADY_TAKEN"), statusCode: 409, message: "Seat is unavailable" },
+];
+
+const MOVE_ERROR_RULES: readonly ErrorRule[] = [
+  { match: exactCode("GAME_NOT_FOUND"), statusCode: 404, message: "Game was not found" },
+  { match: exactCode("GAME_NOT_ACTIVE"), statusCode: 409, message: "Move cannot be applied in current game state" },
+  { match: exactCode("NOT_YOUR_TURN"), statusCode: 409, message: "Move cannot be applied in current game state" },
+  { match: exactCode("VERSION_CONFLICT"), statusCode: 409, message: "Move cannot be applied in current game state" },
+  { match: prefixCode("ILLEGAL_MOVE:"), statusCode: 400, message: (code) => code, responseCode: "ILLEGAL_MOVE" },
+];
+
+const RESIGN_ERROR_RULES: readonly ErrorRule[] = [
+  { match: exactCode("GAME_NOT_FOUND"), statusCode: 404, message: "Game was not found" },
+  { match: exactCode("GAME_ALREADY_FINISHED"), statusCode: 409, message: "Game is already finished" },
+];
 
 async function authenticateActor(
   req: IncomingMessage,
@@ -89,16 +147,7 @@ async function handleRequest(
       return;
     } catch (error) {
       const code = getErrorCode(error, "UNKNOWN");
-      if (code === "GAME_NOT_FOUND") {
-        respondError(res, ctx, 404, code, "Game was not found", { gameId });
-        return;
-      }
-      if (code === "INVALID_JOIN_TOKEN") {
-        respondError(res, ctx, 401, code, "Join token is invalid", { gameId });
-        return;
-      }
-      if (code === "GAME_IS_FULL" || code === "SEAT_ALREADY_TAKEN") {
-        respondError(res, ctx, 409, code, "Seat is unavailable", { gameId });
+      if (respondIfMappedError(res, ctx, code, { gameId }, JOIN_ERROR_RULES)) {
         return;
       }
       throw error;
@@ -186,16 +235,7 @@ async function handleRequest(
       return;
     } catch (error) {
       const code = getErrorCode(error, "UNKNOWN");
-      if (code === "GAME_NOT_FOUND") {
-        respondError(res, ctx, 404, code, "Game was not found", { gameId, guestId: actor.guestId });
-        return;
-      }
-      if (code === "GAME_NOT_ACTIVE" || code === "NOT_YOUR_TURN" || code === "VERSION_CONFLICT") {
-        respondError(res, ctx, 409, code, "Move cannot be applied in current game state", { gameId, guestId: actor.guestId });
-        return;
-      }
-      if (code.startsWith("ILLEGAL_MOVE:")) {
-        respondError(res, ctx, 400, "ILLEGAL_MOVE", code, { gameId, guestId: actor.guestId });
+      if (respondIfMappedError(res, ctx, code, { gameId, guestId: actor.guestId }, MOVE_ERROR_RULES)) {
         return;
       }
       throw error;
@@ -217,12 +257,7 @@ async function handleRequest(
       return;
     } catch (error) {
       const code = getErrorCode(error, "UNKNOWN");
-      if (code === "GAME_NOT_FOUND") {
-        respondError(res, ctx, 404, code, "Game was not found", { gameId, guestId: actor.guestId });
-        return;
-      }
-      if (code === "GAME_ALREADY_FINISHED") {
-        respondError(res, ctx, 409, code, "Game is already finished", { gameId, guestId: actor.guestId });
+      if (respondIfMappedError(res, ctx, code, { gameId, guestId: actor.guestId }, RESIGN_ERROR_RULES)) {
         return;
       }
       throw error;

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -82,8 +82,8 @@ type MoveRow = {
   created_at: string | Date;
 };
 
-type MaxPlyRow = {
-  max_ply: number | string | null;
+type LastPlyRow = {
+  ply: number | string;
 };
 
 export interface GameStore {
@@ -440,7 +440,11 @@ export class InMemoryStore implements GameStore {
     game.updatedAt = toIsoNow();
     game.version += 1;
 
-    const moves = this.movesByGame.get(gameId) ?? [];
+    const moves = this.movesByGame.get(gameId);
+    if (!moves) {
+      throw new Error("GAME_NOT_FOUND");
+    }
+
     moves.push({
       ply: moves.length + 1,
       actorSeat: actor.seat,
@@ -448,7 +452,6 @@ export class InMemoryStore implements GameStore {
       stateAfter: result.value,
       createdAt: toIsoNow(),
     });
-    this.movesByGame.set(gameId, moves);
 
     return game;
   }
@@ -801,13 +804,15 @@ export class PostgresStore implements GameStore {
 
       await this.updateGame(client, game, previousVersion);
 
-      const maxPlyResult = await client.query<MaxPlyRow>(
-        `SELECT COALESCE(MAX(ply), 0) AS max_ply
+      const lastMoveResult = await client.query<LastPlyRow>(
+        `SELECT ply
          FROM moves
-         WHERE game_id = $1`,
+         WHERE game_id = $1
+         ORDER BY ply DESC
+         LIMIT 1`,
         [gameId],
       );
-      const nextPly = toNumber(maxPlyResult.rows[0]?.max_ply) + 1;
+      const nextPly = toNumber(lastMoveResult.rows[0]?.ply) + 1;
 
       await client.query(
         `INSERT INTO moves (

--- a/server/src/validators.ts
+++ b/server/src/validators.ts
@@ -8,24 +8,32 @@ export type MoveRequestBody = {
 
 type JsonRecord = Record<string, unknown>;
 
+const BOARD_MIN_INDEX = 0;
+const BOARD_MAX_INDEX = 8;
+const MIN_MAIN_MINUTES = 1;
+const MIN_BYO_SECONDS = 0;
+const BYO_SECONDS_STEP = 10;
+const MIN_PLAYER_NAME_LENGTH = 2;
+const MAX_PLAYER_NAME_LENGTH = 20;
+const MIN_JOIN_TOKEN_LENGTH = 16;
+const VALID_SEATS = new Set<JoinGameInput["seat"]>(["black", "white"]);
 const DROP_KINDS = new Set(["rook", "bishop", "gold", "silver", "knight", "lance", "pawn"]);
 
 function isRecord(input: unknown): input is JsonRecord {
   return !!input && typeof input === "object";
 }
 
+function isIntegerInRange(value: unknown, min: number, max: number): value is number {
+  return Number.isInteger(value) && (value as number) >= min && (value as number) <= max;
+}
+
 function isPosition(input: unknown): input is { x: number; y: number } {
   if (!isRecord(input)) {
     return false;
   }
-  return (
-    Number.isInteger(input.x) &&
-    Number.isInteger(input.y) &&
-    (input.x as number) >= 0 &&
-    (input.x as number) <= 8 &&
-    (input.y as number) >= 0 &&
-    (input.y as number) <= 8
-  );
+
+  return isIntegerInRange(input.x, BOARD_MIN_INDEX, BOARD_MAX_INDEX)
+    && isIntegerInRange(input.y, BOARD_MIN_INDEX, BOARD_MAX_INDEX);
 }
 
 function isMoveShape(input: unknown): input is Move {
@@ -53,14 +61,16 @@ export function isValidCreateGameInput(input: unknown): input is CreateGameInput
     return false;
   }
 
-  if (!Number.isInteger(input.mainMinutes) || (input.mainMinutes as number) <= 0) {
+  if (!isIntegerInRange(input.mainMinutes, MIN_MAIN_MINUTES, Number.MAX_SAFE_INTEGER)) {
     return false;
   }
-  if (!Number.isInteger(input.byoSeconds) || (input.byoSeconds as number) < 0) {
+
+  if (!isIntegerInRange(input.byoSeconds, MIN_BYO_SECONDS, Number.MAX_SAFE_INTEGER)) {
     return false;
   }
+
   const byoSeconds = input.byoSeconds as number;
-  return byoSeconds === 0 || byoSeconds % 10 === 0;
+  return byoSeconds === MIN_BYO_SECONDS || byoSeconds % BYO_SECONDS_STEP === 0;
 }
 
 export function isValidJoinGameInput(input: unknown): input is JoinGameInput {
@@ -70,13 +80,15 @@ export function isValidJoinGameInput(input: unknown): input is JoinGameInput {
 
   const name = typeof input.name === "string" ? input.name : "";
   const trimmed = name.trim();
-  if (!trimmed || trimmed.length < 2 || trimmed.length > 20) {
+  if (!trimmed || trimmed.length < MIN_PLAYER_NAME_LENGTH || trimmed.length > MAX_PLAYER_NAME_LENGTH) {
     return false;
   }
-  if (input.seat !== "black" && input.seat !== "white") {
+
+  if (!VALID_SEATS.has(input.seat as JoinGameInput["seat"])) {
     return false;
   }
-  return typeof input.joinToken === "string" && input.joinToken.length >= 16;
+
+  return typeof input.joinToken === "string" && input.joinToken.length >= MIN_JOIN_TOKEN_LENGTH;
 }
 
 export function isMoveRequestBody(input: unknown): input is MoveRequestBody {

--- a/server/tests/validators.test.ts
+++ b/server/tests/validators.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vitest";
+import { isMoveRequestBody, isValidCreateGameInput, isValidJoinGameInput } from "../src/validators";
+
+describe("validators", () => {
+  describe("isValidCreateGameInput", () => {
+    test("accepts integer values within allowed range", () => {
+      expect(isValidCreateGameInput({ mainMinutes: 1, byoSeconds: 0 })).toBe(true);
+      expect(isValidCreateGameInput({ mainMinutes: 10, byoSeconds: 30 })).toBe(true);
+    });
+
+    test("rejects invalid mainMinutes and byoSeconds", () => {
+      expect(isValidCreateGameInput(null)).toBe(false);
+      expect(isValidCreateGameInput({ mainMinutes: 0, byoSeconds: 30 })).toBe(false);
+      expect(isValidCreateGameInput({ mainMinutes: 5.5, byoSeconds: 30 })).toBe(false);
+      expect(isValidCreateGameInput({ mainMinutes: 5, byoSeconds: -1 })).toBe(false);
+      expect(isValidCreateGameInput({ mainMinutes: 5, byoSeconds: 15 })).toBe(false);
+    });
+  });
+
+  describe("isValidJoinGameInput", () => {
+    test("accepts a trimmed name, seat, and join token", () => {
+      expect(
+        isValidJoinGameInput({
+          name: "  player  ",
+          seat: "black",
+          joinToken: "a".repeat(16),
+        }),
+      ).toBe(true);
+    });
+
+    test("rejects invalid name / seat / join token", () => {
+      expect(isValidJoinGameInput({ name: "a", seat: "black", joinToken: "a".repeat(16) })).toBe(false);
+      expect(isValidJoinGameInput({ name: " ".repeat(3), seat: "black", joinToken: "a".repeat(16) })).toBe(false);
+      expect(isValidJoinGameInput({ name: "a".repeat(21), seat: "black", joinToken: "a".repeat(16) })).toBe(false);
+      expect(isValidJoinGameInput({ name: "player", seat: "blue", joinToken: "a".repeat(16) })).toBe(false);
+      expect(isValidJoinGameInput({ name: "player", seat: "white", joinToken: "short" })).toBe(false);
+    });
+  });
+
+  describe("isMoveRequestBody", () => {
+    test("accepts board move and drop move payloads", () => {
+      expect(
+        isMoveRequestBody({
+          expectedVersion: 3,
+          move: { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },
+        }),
+      ).toBe(true);
+
+      expect(
+        isMoveRequestBody({
+          expectedVersion: 3,
+          move: { from: { x: 1, y: 6 }, to: { x: 1, y: 5 }, promote: false },
+        }),
+      ).toBe(true);
+
+      expect(
+        isMoveRequestBody({
+          expectedVersion: 2,
+          move: { drop: "pawn", to: { x: 4, y: 4 } },
+        }),
+      ).toBe(true);
+    });
+
+    test("rejects invalid versions and move shapes", () => {
+      expect(
+        isMoveRequestBody({
+          expectedVersion: 0,
+          move: { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },
+        }),
+      ).toBe(false);
+
+      expect(
+        isMoveRequestBody({
+          expectedVersion: 1.1,
+          move: { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },
+        }),
+      ).toBe(false);
+
+      expect(
+        isMoveRequestBody({
+          expectedVersion: 2,
+          move: { from: { x: -1, y: 6 }, to: { x: 0, y: 5 } },
+        }),
+      ).toBe(false);
+
+      expect(
+        isMoveRequestBody({
+          expectedVersion: 2,
+          move: { from: { x: 0, y: 6 }, to: { x: 0, y: 5 }, promote: "yes" },
+        }),
+      ).toBe(false);
+
+      expect(
+        isMoveRequestBody({
+          expectedVersion: 2,
+          move: { drop: "king", to: { x: 4, y: 4 } },
+        }),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
  - サーバーのバリデーションを共通化（条件・閾値の定数化、重複ロジック整理）
  - サーバーのAPIエラーハンドリング分岐をルール化（重複 if の削減）
  - Postgres の次手数取得を ORDER BY ply DESC LIMIT 1 に変更（既存インデックス活用を意識）
  - フロントの API クライアントでヘッダー組み立て処理を共通化（DRY化）
      - app/tests/moveText.test.ts
      - app/tests/position.test.ts
      - app/tests/gameApi.test.ts に baseUrl 正規化ケース追加