### PR TITLE
Issue #70: 対局時計の過剰消費とリアルタイム表示の不具合修正

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -9,7 +9,15 @@ import { type BoardMove, type Color, type GameState, type Move, type PieceKind, 
 import { PIECE_SOUND_PATH } from "./assets";
 import { formatMoveText, oppositeColor, sideLabel, winnerLabel } from "./game/moveText";
 import { positionToKey } from "./game/position";
-import { createClockState, DEFAULT_TIME_CONTROL, formatClockText, normalizeTimeControl, type ClockState, type TimeControl } from "./game/timeControl";
+import {
+  createClockState,
+  DEFAULT_TIME_CONTROL,
+  formatClockText,
+  normalizeTimeControl,
+  projectClockState,
+  type ClockState,
+  type TimeControl,
+} from "./game/timeControl";
 import { canOperateTurn, getTurnLockMessage } from "./game/turnControl";
 import {
   ApiClientError,
@@ -95,6 +103,8 @@ export function App() {
 
   const [state, setState] = useState<GameState>(initialState);
   const [clockState, setClockState] = useState<ClockState>(() => createClockState(initialTimeControl));
+  const [clockTurnStartedAtMs, setClockTurnStartedAtMs] = useState<number>(() => Date.now());
+  const [clockNowMs, setClockNowMs] = useState<number>(() => Date.now());
   const [gameVersion, setGameVersion] = useState<number>(1);
   const [selected, setSelected] = useState<Position | null>(null);
   const [selectedDrop, setSelectedDrop] = useState<PieceKind | null>(null);
@@ -187,6 +197,8 @@ export function App() {
     (snapshot: GameSnapshot, options: { showDialog?: boolean } = {}) => {
       setState(snapshot.state);
       setClockState(toClockState(snapshot));
+      setClockTurnStartedAtMs(snapshot.turnStartedAtMs);
+      setClockNowMs(Date.now());
       setGameVersion(snapshot.version);
       latestVersionRef.current = snapshot.version;
       setWinner(snapshot.winner);
@@ -468,6 +480,8 @@ export function App() {
       setNetworkBannerMessage(null);
       setState(initialState);
       setClockState(createClockState(initialTimeControl));
+      setClockTurnStartedAtMs(Date.now());
+      setClockNowMs(Date.now());
       setGameVersion(1);
       latestVersionRef.current = 1;
       clearSelections();
@@ -528,6 +542,8 @@ export function App() {
       setScreenMode("game");
       setState(initialState);
       setClockState(createClockState(initialTimeControl));
+      setClockTurnStartedAtMs(Date.now());
+      setClockNowMs(Date.now());
       setGameVersion(1);
       latestVersionRef.current = 1;
       setWinner(null);
@@ -654,6 +670,23 @@ export function App() {
       window.removeEventListener("online", handleOnline);
     };
   }, [matchMode, screenMode, onlineGameId, gameOver, syncSnapshot]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (screenMode !== "game" || matchMode !== "online" || gameOver) {
+      return;
+    }
+
+    const timerId = window.setInterval(() => {
+      setClockNowMs(Date.now());
+    }, 250);
+
+    return () => {
+      window.clearInterval(timerId);
+    };
+  }, [screenMode, matchMode, gameOver]);
 
   const checkedKing = useMemo(() => {
     if (!isInCheck(state)) {
@@ -972,6 +1005,8 @@ export function App() {
     setGameOver(false);
     setState(initialState);
     setClockState(createClockState(initialTimeControl));
+    setClockTurnStartedAtMs(Date.now());
+    setClockNowMs(Date.now());
     setGameVersion(1);
     latestVersionRef.current = 1;
     replaceSpectateLocation(null);
@@ -1097,6 +1132,14 @@ export function App() {
           ? `観戦中: ${winnerLabel(state.turn)}の手番`
           : `手番: ${winnerLabel(state.turn)}`;
 
+  const displayClockState = useMemo(() => {
+    if (screenMode !== "game" || matchMode !== "online" || gameOver) {
+      return clockState;
+    }
+
+    return projectClockState(clockState, state.turn, clockTurnStartedAtMs, clockNowMs);
+  }, [screenMode, matchMode, gameOver, clockState, state.turn, clockTurnStartedAtMs, clockNowMs]);
+
   return (
     <main className="app">
       <h1>Shogi Game</h1>
@@ -1161,7 +1204,7 @@ export function App() {
           />
           <div className="clock-panel">
             <p className="clock-title">持ち時間</p>
-            <p className="clock-main">{formatClockText(clockState.main.white, clockState.byo.white)}</p>
+            <p className="clock-main">{formatClockText(displayClockState.main.white, displayClockState.byo.white)}</p>
           </div>
           <section className="history-panel" aria-label="move history">
             <h2>棋譜</h2>
@@ -1185,7 +1228,7 @@ export function App() {
         <div className="hand-anchor hand-anchor-black">
           <div className="clock-panel">
             <p className="clock-title">持ち時間</p>
-            <p className="clock-main">{formatClockText(clockState.main.black, clockState.byo.black)}</p>
+            <p className="clock-main">{formatClockText(displayClockState.main.black, displayClockState.byo.black)}</p>
           </div>
           <Hand
             hands={state.hands}

--- a/app/src/game/timeControl.ts
+++ b/app/src/game/timeControl.ts
@@ -34,6 +34,30 @@ export function formatClockText(mainSeconds: number, byoSeconds: number): string
   return `秒読み ${formatSeconds(byoSeconds)}`;
 }
 
+export function projectClockState(base: ClockState, turn: Color, turnStartedAtMs: number, nowMs: number): ClockState {
+  const elapsedSeconds = Math.floor(Math.max(0, nowMs - turnStartedAtMs) / 1000);
+  if (elapsedSeconds <= 0) {
+    return base;
+  }
+
+  const projected: ClockState = {
+    main: { ...base.main },
+    byo: { ...base.byo },
+  };
+
+  const mainSeconds = base.main[turn];
+  const byoSeconds = base.byo[turn];
+  if (elapsedSeconds <= mainSeconds) {
+    projected.main[turn] = mainSeconds - elapsedSeconds;
+    return projected;
+  }
+
+  const overtime = elapsedSeconds - mainSeconds;
+  projected.main[turn] = 0;
+  projected.byo[turn] = Math.max(0, byoSeconds - overtime);
+  return projected;
+}
+
 export function normalizeTimeControl(mainMinutes: number, byoSeconds: number): TimeControl {
   return {
     mainSeconds: Math.max(0, Math.floor(mainMinutes)) * 60,

--- a/app/tests/timeControl.test.ts
+++ b/app/tests/timeControl.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatClockText, normalizeTimeControl } from "../src/game/timeControl";
+import { formatClockText, normalizeTimeControl, projectClockState } from "../src/game/timeControl";
 
 describe("timeControl helpers", () => {
   it("normalizes user input by minute and 10-second units", () => {
@@ -10,5 +10,36 @@ describe("timeControl helpers", () => {
   it("switches display to byo-yomi after main time reaches zero", () => {
     expect(formatClockText(125, 30)).toBe("02:05");
     expect(formatClockText(0, 30)).toBe("秒読み 00:30");
+  });
+
+  it("projects active turn clock by elapsed seconds", () => {
+    const projected = projectClockState(
+      {
+        main: { black: 100, white: 100 },
+        byo: { black: 30, white: 30 },
+      },
+      "black",
+      1_000_000,
+      1_004_000,
+    );
+
+    expect(projected.main.black).toBe(96);
+    expect(projected.main.white).toBe(100);
+    expect(projected.byo.black).toBe(30);
+  });
+
+  it("counts down byo-yomi after main time is exhausted", () => {
+    const projected = projectClockState(
+      {
+        main: { black: 0, white: 100 },
+        byo: { black: 30, white: 30 },
+      },
+      "black",
+      1_000_000,
+      1_010_000,
+    );
+
+    expect(projected.main.black).toBe(0);
+    expect(projected.byo.black).toBe(20);
   });
 });

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -140,39 +140,133 @@ function oppositeSeat(seat: Seat): Seat {
   return seat === "black" ? "white" : "black";
 }
 
-function applyElapsedClock(game: PersistedGame, seat: Seat, nowMs: number): boolean {
-  const elapsedSeconds = Math.ceil(Math.max(0, nowMs - game.turnStartedAtMs) / 1000);
+type TurnClockProjection = {
+  remainingMainSeconds: number;
+  remainingByoSeconds: number;
+  timedOut: boolean;
+};
 
-  if (seat === "black") {
-    if (elapsedSeconds <= game.mainSecondsBlack) {
-      game.mainSecondsBlack -= elapsedSeconds;
-      return false;
-    }
-    const overtime = elapsedSeconds - game.mainSecondsBlack;
-    game.mainSecondsBlack = 0;
-    return overtime > game.byoSecondsBlack;
-  }
+type SnapshotClockProjection = {
+  mainSecondsBlack: number;
+  mainSecondsWhite: number;
+  byoSecondsBlack: number;
+  byoSecondsWhite: number;
+  turnStartedAtMs: number;
+  timedOut: boolean;
+};
 
-  if (elapsedSeconds <= game.mainSecondsWhite) {
-    game.mainSecondsWhite -= elapsedSeconds;
-    return false;
-  }
-
-  const overtime = elapsedSeconds - game.mainSecondsWhite;
-  game.mainSecondsWhite = 0;
-  return overtime > game.byoSecondsWhite;
+function getElapsedWholeSeconds(turnStartedAtMs: number, nowMs: number): number {
+  return Math.floor(Math.max(0, nowMs - turnStartedAtMs) / 1000);
 }
 
-function settleTimeoutIfNeeded(game: PersistedGame, nowMs: number): boolean {
+function projectTurnClock(mainSeconds: number, byoSeconds: number, elapsedSeconds: number): TurnClockProjection {
+  if (elapsedSeconds <= 0) {
+    return {
+      remainingMainSeconds: mainSeconds,
+      remainingByoSeconds: byoSeconds,
+      timedOut: false,
+    };
+  }
+
+  if (elapsedSeconds <= mainSeconds) {
+    return {
+      remainingMainSeconds: mainSeconds - elapsedSeconds,
+      remainingByoSeconds: byoSeconds,
+      timedOut: false,
+    };
+  }
+
+  const overtime = elapsedSeconds - mainSeconds;
+  return {
+    remainingMainSeconds: 0,
+    remainingByoSeconds: Math.max(0, byoSeconds - overtime),
+    timedOut: overtime > byoSeconds,
+  };
+}
+
+function projectClockForSnapshot(game: PersistedGame, nowMs: number): SnapshotClockProjection {
+  const base: SnapshotClockProjection = {
+    mainSecondsBlack: game.mainSecondsBlack,
+    mainSecondsWhite: game.mainSecondsWhite,
+    byoSecondsBlack: game.byoSecondsBlack,
+    byoSecondsWhite: game.byoSecondsWhite,
+    turnStartedAtMs: game.turnStartedAtMs,
+    timedOut: false,
+  };
+
+  if (game.status !== "active") {
+    return base;
+  }
+
+  const elapsedSeconds = getElapsedWholeSeconds(game.turnStartedAtMs, nowMs);
+  if (elapsedSeconds <= 0) {
+    return base;
+  }
+
+  if (game.turn === "black") {
+    const projected = projectTurnClock(game.mainSecondsBlack, game.byoSecondsBlack, elapsedSeconds);
+    return {
+      ...base,
+      mainSecondsBlack: projected.remainingMainSeconds,
+      byoSecondsBlack: projected.remainingByoSeconds,
+      turnStartedAtMs: game.turnStartedAtMs + elapsedSeconds * 1000,
+      timedOut: projected.timedOut,
+    };
+  }
+
+  const projected = projectTurnClock(game.mainSecondsWhite, game.byoSecondsWhite, elapsedSeconds);
+  return {
+    ...base,
+    mainSecondsWhite: projected.remainingMainSeconds,
+    byoSecondsWhite: projected.remainingByoSeconds,
+    turnStartedAtMs: game.turnStartedAtMs + elapsedSeconds * 1000,
+    timedOut: projected.timedOut,
+  };
+}
+
+function consumeElapsedClock(game: PersistedGame, nowMs: number): boolean {
   if (game.status !== "active") {
     return false;
   }
 
-  const timedOut = applyElapsedClock(game, game.turn, nowMs);
-  if (!timedOut) {
+  const elapsedSeconds = getElapsedWholeSeconds(game.turnStartedAtMs, nowMs);
+  if (elapsedSeconds <= 0) {
     return false;
   }
 
+  if (game.turn === "black") {
+    const projected = projectTurnClock(game.mainSecondsBlack, game.byoSecondsBlack, elapsedSeconds);
+    game.mainSecondsBlack = projected.remainingMainSeconds;
+    game.turnStartedAtMs += elapsedSeconds * 1000;
+    if (!projected.timedOut) {
+      return false;
+    }
+  } else {
+    const projected = projectTurnClock(game.mainSecondsWhite, game.byoSecondsWhite, elapsedSeconds);
+    game.mainSecondsWhite = projected.remainingMainSeconds;
+    game.turnStartedAtMs += elapsedSeconds * 1000;
+    if (!projected.timedOut) {
+      return false;
+    }
+  }
+
+  game.status = "finished";
+  game.resultType = "timeout";
+  game.winner = oppositeSeat(game.turn);
+  game.updatedAt = new Date(nowMs).toISOString();
+  game.version += 1;
+  return true;
+}
+
+function settleTimeoutIfNeeded(game: PersistedGame, nowMs: number): boolean {
+  const projected = projectClockForSnapshot(game, nowMs);
+  if (!projected.timedOut) {
+    return false;
+  }
+
+  game.mainSecondsBlack = projected.mainSecondsBlack;
+  game.mainSecondsWhite = projected.mainSecondsWhite;
+  game.turnStartedAtMs = projected.turnStartedAtMs;
   game.status = "finished";
   game.resultType = "timeout";
   game.winner = oppositeSeat(game.turn);
@@ -197,6 +291,58 @@ function toGame(snapshot: PersistedGame): Game {
     turnStartedAtMs: snapshot.turnStartedAtMs,
     createdAt: snapshot.createdAt,
     updatedAt: snapshot.updatedAt,
+  };
+}
+
+function toPersistedGame(game: Game, joinTokenHash = ""): PersistedGame {
+  return {
+    id: game.id,
+    status: game.status,
+    turn: game.turn,
+    state: game.state,
+    mainSecondsBlack: game.mainSecondsBlack,
+    mainSecondsWhite: game.mainSecondsWhite,
+    byoSecondsBlack: game.byoSecondsBlack,
+    byoSecondsWhite: game.byoSecondsWhite,
+    resultType: game.resultType,
+    winner: game.winner,
+    version: game.version,
+    turnStartedAtMs: game.turnStartedAtMs,
+    createdAt: game.createdAt,
+    updatedAt: game.updatedAt,
+    joinTokenHash,
+  };
+}
+
+function toProjectedGame(snapshot: PersistedGame, nowMs: number): Game {
+  if (snapshot.status !== "active") {
+    return toGame(snapshot);
+  }
+
+  const projected = projectClockForSnapshot(snapshot, nowMs);
+  if (projected.timedOut) {
+    return {
+      ...toGame(snapshot),
+      mainSecondsBlack: projected.mainSecondsBlack,
+      mainSecondsWhite: projected.mainSecondsWhite,
+      byoSecondsBlack: projected.byoSecondsBlack,
+      byoSecondsWhite: projected.byoSecondsWhite,
+      turnStartedAtMs: projected.turnStartedAtMs,
+      status: "finished",
+      resultType: "timeout",
+      winner: oppositeSeat(snapshot.turn),
+      version: snapshot.version + 1,
+      updatedAt: new Date(nowMs).toISOString(),
+    };
+  }
+
+  return {
+    ...toGame(snapshot),
+    mainSecondsBlack: projected.mainSecondsBlack,
+    mainSecondsWhite: projected.mainSecondsWhite,
+    byoSecondsBlack: projected.byoSecondsBlack,
+    byoSecondsWhite: projected.byoSecondsWhite,
+    turnStartedAtMs: projected.turnStartedAtMs,
   };
 }
 
@@ -267,30 +413,31 @@ export class InMemoryStore implements GameStore {
   private readonly playersByGame = new Map<string, Player[]>();
   private readonly movesByGame = new Map<string, MoveRecord[]>();
 
-  private settleTimeoutIfNeeded(game: Game): void {
-    const snapshot: PersistedGame = {
-      id: game.id,
-      status: game.status,
-      turn: game.turn,
-      state: game.state,
-      mainSecondsBlack: game.mainSecondsBlack,
-      mainSecondsWhite: game.mainSecondsWhite,
-      byoSecondsBlack: game.byoSecondsBlack,
-      byoSecondsWhite: game.byoSecondsWhite,
-      resultType: game.resultType,
-      winner: game.winner,
-      version: game.version,
-      turnStartedAtMs: game.turnStartedAtMs,
-      createdAt: game.createdAt,
-      updatedAt: game.updatedAt,
-      joinTokenHash: "",
-    };
-
-    const changed = settleTimeoutIfNeeded(snapshot, Date.now());
+  private settleTimeoutIfNeeded(game: Game, nowMs: number): void {
+    const snapshot = toPersistedGame(game);
+    const changed = settleTimeoutIfNeeded(snapshot, nowMs);
+    if (!changed) {
+      return;
+    }
 
     game.mainSecondsBlack = snapshot.mainSecondsBlack;
     game.mainSecondsWhite = snapshot.mainSecondsWhite;
-    if (changed) {
+    game.turnStartedAtMs = snapshot.turnStartedAtMs;
+    game.status = snapshot.status;
+    game.resultType = snapshot.resultType;
+    game.winner = snapshot.winner;
+    game.updatedAt = snapshot.updatedAt;
+    game.version = snapshot.version;
+  }
+
+  private consumeElapsedClockProgress(game: Game, nowMs: number): void {
+    const snapshot = toPersistedGame(game);
+    consumeElapsedClock(snapshot, nowMs);
+
+    game.mainSecondsBlack = snapshot.mainSecondsBlack;
+    game.mainSecondsWhite = snapshot.mainSecondsWhite;
+    game.turnStartedAtMs = snapshot.turnStartedAtMs;
+    if (snapshot.status === "finished") {
       game.status = snapshot.status;
       game.resultType = snapshot.resultType;
       game.winner = snapshot.winner;
@@ -407,8 +554,9 @@ export class InMemoryStore implements GameStore {
     if (!game) {
       return null;
     }
-    this.settleTimeoutIfNeeded(game);
-    return game;
+    const nowMs = Date.now();
+    this.settleTimeoutIfNeeded(game, nowMs);
+    return toProjectedGame(toPersistedGame(game), nowMs);
   }
 
   async submitMove(gameId: string, actor: Player, move: Move, expectedVersion: number): Promise<Game> {
@@ -417,7 +565,7 @@ export class InMemoryStore implements GameStore {
       throw new Error("GAME_NOT_FOUND");
     }
 
-    this.settleTimeoutIfNeeded(game);
+    this.consumeElapsedClockProgress(game, Date.now());
 
     if (expectedVersion !== game.version) {
       throw new Error("VERSION_CONFLICT");
@@ -462,7 +610,7 @@ export class InMemoryStore implements GameStore {
       throw new Error("GAME_NOT_FOUND");
     }
 
-    this.settleTimeoutIfNeeded(game);
+    this.consumeElapsedClockProgress(game, Date.now());
 
     if (game.status === "finished") {
       throw new Error("GAME_ALREADY_FINISHED");
@@ -759,12 +907,14 @@ export class PostgresStore implements GameStore {
         return null;
       }
 
-      const timedOut = settleTimeoutIfNeeded(game, Date.now());
+      const nowMs = Date.now();
+      const timedOut = settleTimeoutIfNeeded(game, nowMs);
       if (timedOut) {
         await this.updateGame(client, game, game.version - 1);
+        return toGame(game);
       }
 
-      return toGame(game);
+      return toProjectedGame(game, nowMs);
     });
   }
 
@@ -775,7 +925,8 @@ export class PostgresStore implements GameStore {
         throw new Error("GAME_NOT_FOUND");
       }
 
-      const timedOut = settleTimeoutIfNeeded(game, Date.now());
+      consumeElapsedClock(game, Date.now());
+      const timedOut = game.status === "finished" && game.resultType === "timeout";
       if (timedOut) {
         await this.updateGame(client, game, game.version - 1);
       }
@@ -837,7 +988,8 @@ export class PostgresStore implements GameStore {
         throw new Error("GAME_NOT_FOUND");
       }
 
-      const timedOut = settleTimeoutIfNeeded(game, Date.now());
+      consumeElapsedClock(game, Date.now());
+      const timedOut = game.status === "finished" && game.resultType === "timeout";
       if (timedOut) {
         await this.updateGame(client, game, game.version - 1);
       }

--- a/server/tests/postgresStore.test.ts
+++ b/server/tests/postgresStore.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from "vitest";
+import { afterAll, describe, expect, test, vi } from "vitest";
 import { newDb } from "pg-mem";
 import { PostgresStore } from "../src/store";
 
@@ -96,5 +96,43 @@ describe("PostgresStore", () => {
         game.version,
       ),
     ).rejects.toThrow("VERSION_CONFLICT");
+  });
+
+  test("does not over-deduct clock on repeated snapshot fetches", async () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(1_000_000);
+
+    const store = new PostgresStore(pool);
+    const created = await store.createGame({ mainMinutes: 5, byoSeconds: 30 });
+    await store.joinGame(created.gameId, {
+      name: "black",
+      seat: "black",
+      joinToken: created.joinToken,
+    });
+    await store.joinGame(created.gameId, {
+      name: "white",
+      seat: "white",
+      joinToken: created.joinToken,
+    });
+
+    await pool.query(
+      `UPDATE games
+       SET status = 'active',
+           turn = 'black',
+           main_seconds_black = 100,
+           turn_started_at_ms = $2
+       WHERE id = $1`,
+      [created.gameId, 1_000_000],
+    );
+
+    nowSpy.mockReturnValue(1_002_000);
+    const firstSnapshot = await store.getGame(created.gameId);
+    expect(firstSnapshot?.mainSecondsBlack).toBe(98);
+
+    nowSpy.mockReturnValue(1_004_000);
+    const secondSnapshot = await store.getGame(created.gameId);
+    expect(secondSnapshot?.mainSecondsBlack).toBe(96);
+
+    nowSpy.mockRestore();
   });
 });

--- a/server/tests/storeClock.test.ts
+++ b/server/tests/storeClock.test.ts
@@ -26,13 +26,9 @@ describe("InMemoryStore clock handling", () => {
       return;
     }
 
-    game.mainSecondsBlack = 100;
-    game.turn = "black";
-    game.status = "active";
-    game.turnStartedAtMs = 1_000_000;
     const expectedVersion = game.version;
 
-    nowSpy.mockReturnValue(1_001_500);
+    nowSpy.mockReturnValue(1_002_000);
 
     const actor = await store.findPlayerByGuestId(created.gameId, black.guestId);
     expect(actor).not.toBeNull();
@@ -48,7 +44,81 @@ describe("InMemoryStore clock handling", () => {
       expectedVersion,
     );
 
-    expect(updated.mainSecondsBlack).toBe(98);
+    expect(updated.mainSecondsBlack).toBe(298);
+    nowSpy.mockRestore();
+  });
+
+  test("does not over-deduct clock on repeated snapshots", async () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(1_000_000);
+
+    const store = new InMemoryStore();
+    const created = await store.createGame({ mainMinutes: 5, byoSeconds: 30 });
+    await store.joinGame(created.gameId, {
+      name: "black",
+      seat: "black",
+      joinToken: created.joinToken,
+    });
+    await store.joinGame(created.gameId, {
+      name: "white",
+      seat: "white",
+      joinToken: created.joinToken,
+    });
+
+    const game = await store.getGame(created.gameId);
+    expect(game).not.toBeNull();
+    if (!game) {
+      nowSpy.mockRestore();
+      return;
+    }
+
+    nowSpy.mockReturnValue(1_002_000);
+    const firstSnapshot = await store.getGame(created.gameId);
+    expect(firstSnapshot?.mainSecondsBlack).toBe(298);
+
+    nowSpy.mockReturnValue(1_004_000);
+    const secondSnapshot = await store.getGame(created.gameId);
+    expect(secondSnapshot?.mainSecondsBlack).toBe(296);
+
+    nowSpy.mockRestore();
+  });
+
+  test("reflects byo-yomi countdown in snapshots and times out after expiration", async () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(1_000_000);
+
+    const store = new InMemoryStore();
+    const created = await store.createGame({ mainMinutes: 0, byoSeconds: 30 });
+    await store.joinGame(created.gameId, {
+      name: "black",
+      seat: "black",
+      joinToken: created.joinToken,
+    });
+    await store.joinGame(created.gameId, {
+      name: "white",
+      seat: "white",
+      joinToken: created.joinToken,
+    });
+
+    const game = await store.getGame(created.gameId);
+    expect(game).not.toBeNull();
+    if (!game) {
+      nowSpy.mockRestore();
+      return;
+    }
+
+    nowSpy.mockReturnValue(1_010_000);
+    const active = await store.getGame(created.gameId);
+    expect(active?.status).toBe("active");
+    expect(active?.mainSecondsBlack).toBe(0);
+    expect(active?.byoSecondsBlack).toBe(20);
+
+    nowSpy.mockReturnValue(1_031_000);
+    const finished = await store.getGame(created.gameId);
+    expect(finished?.status).toBe("finished");
+    expect(finished?.resultType).toBe("timeout");
+    expect(finished?.winner).toBe("white");
+
     nowSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## 概要
- サーバ側で時計の過剰減算を修正
- クライアント側で時計をリアルタイム表示に修正
- InMemory/Postgres/UI の回帰テストを追加

## 動作確認
- npm run test
- npm run build