### PR TITLE
Issue #76: 対局同期をWebSocket中心のリアルタイム更新へ移行

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -23,8 +23,9 @@ import {
 } from "./online/gameApi";
 import { buildResultText, toClockState } from "./online/gameSnapshot";
 import { formatLobbyError, validateCreateGameForm, validateJoinGameForm, validateSpectateGameForm } from "./online/lobbyValidation";
-import { getPollingIntervalMs, shouldApplySnapshot } from "./online/pollingPolicy";
+import { shouldApplySnapshot } from "./online/pollingPolicy";
 import { computePollingRetryDelayMs, isRetryableNetworkError } from "./online/networkRecovery";
+import { buildGameEventsWebSocketUrl, parseRealtimeSnapshotMessage } from "./online/realtimeEvents";
 import { clearStoredSession, loadStoredSession, saveStoredSession } from "./online/sessionPersistence";
 import { buildSpectatorUrl, parseSpectateGameId } from "./online/spectatorLink";
 import { chooseRandomMove } from "../../bot/src/randomBot";
@@ -113,8 +114,6 @@ export function App() {
   const [isSubmittingResign, setIsSubmittingResign] = useState(false);
   const pieceSoundRef = useRef<HTMLAudioElement | null>(null);
   const latestVersionRef = useRef(gameVersion);
-  const pollingInFlightRef = useRef(false);
-  const pollingFailureCountRef = useRef(0);
   const hasAutoStartedSpectateRef = useRef(false);
 
   useEffect(() => {
@@ -560,66 +559,122 @@ export function App() {
   }, [initialSpectateGameId, startSpectatingByGameId]);
 
   useEffect(() => {
-    if (screenMode !== "game" || matchMode !== "online" || !onlineGameId || gameOver) {
+    if (
+      typeof window === "undefined"
+      || typeof WebSocket === "undefined"
+      || screenMode !== "game"
+      || matchMode !== "online"
+      || !onlineGameId
+      || gameOver
+      || isOffline
+    ) {
       return;
     }
 
     let disposed = false;
-    let timerId: number | null = null;
+    let socket: WebSocket | null = null;
+    let reconnectTimerId: number | null = null;
+    let reconnectFailureCount = 0;
 
-    const scheduleNext = () => {
-      if (disposed) {
+    const clearSocket = () => {
+      if (!socket) {
         return;
       }
-      const baseIntervalMs = getPollingIntervalMs(document.hidden);
-      const delayMs = computePollingRetryDelayMs(baseIntervalMs, pollingFailureCountRef.current);
-      timerId = window.setTimeout(() => {
-        void pollOnce();
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onerror = null;
+      socket.onclose = null;
+      socket.close();
+      socket = null;
+    };
+
+    const clearReconnectTimer = () => {
+      if (reconnectTimerId !== null) {
+        window.clearTimeout(reconnectTimerId);
+        reconnectTimerId = null;
+      }
+    };
+
+    const scheduleReconnect = () => {
+      if (disposed || reconnectTimerId !== null) {
+        return;
+      }
+      const delayMs = computePollingRetryDelayMs(1000, reconnectFailureCount);
+      reconnectFailureCount += 1;
+      reconnectTimerId = window.setTimeout(() => {
+        reconnectTimerId = null;
+        connect();
       }, delayMs);
     };
 
-    const pollOnce = async () => {
+    const connect = () => {
       if (disposed) {
         return;
       }
-      if (pollingInFlightRef.current) {
-        scheduleNext();
+      clearSocket();
+      clearReconnectTimer();
+
+      try {
+        const wsUrl = buildGameEventsWebSocketUrl(onlineGameId);
+        socket = new WebSocket(wsUrl);
+      } catch {
+        setNetworkBannerMessage("リアルタイム接続に失敗しました。再接続を試行します。");
+        scheduleReconnect();
         return;
       }
 
-      pollingInFlightRef.current = true;
-      try {
-        const synced = await syncSnapshot(onlineGameId, {
+      socket.onopen = () => {
+        reconnectFailureCount = 0;
+        setNetworkBannerMessage(null);
+        void syncSnapshot(onlineGameId, {
           showDialog: false,
           suppressError: true,
           onlyIfVersionAdvanced: true,
           background: true,
-        });
-
-        if (synced) {
-          pollingFailureCountRef.current = 0;
-          if (!isOffline) {
-            setNetworkBannerMessage(null);
+        }).then((synced) => {
+          if (synced) {
+            setGameMessage(null);
           }
-        } else {
-          pollingFailureCountRef.current += 1;
+        });
+      };
+
+      socket.onmessage = (event) => {
+        const snapshot = parseRealtimeSnapshotMessage(event.data);
+        if (!snapshot || snapshot.id !== onlineGameId) {
+          return;
         }
-      } finally {
-        pollingInFlightRef.current = false;
-        scheduleNext();
-      }
+        if (!shouldApplySnapshot(latestVersionRef.current, snapshot.version)) {
+          return;
+        }
+        applySnapshot(snapshot, { showDialog: false });
+        setGameMessage(null);
+        setNetworkBannerMessage(null);
+      };
+
+      socket.onerror = () => {
+        if (disposed) {
+          return;
+        }
+        setNetworkBannerMessage("リアルタイム同期が不安定です。再接続を試行します。");
+      };
+
+      socket.onclose = () => {
+        if (disposed) {
+          return;
+        }
+        setNetworkBannerMessage("リアルタイム接続が切断されました。再接続しています。");
+        scheduleReconnect();
+      };
     };
 
-    scheduleNext();
+    connect();
 
     return () => {
       disposed = true;
-      pollingInFlightRef.current = false;
-      if (timerId !== null) {
-        window.clearTimeout(timerId);
-      }
+      clearReconnectTimer();
+      clearSocket();
     };
-  }, [screenMode, matchMode, onlineGameId, gameOver, syncSnapshot, isOffline]);
+  }, [screenMode, matchMode, onlineGameId, gameOver, isOffline, syncSnapshot, applySnapshot]);
 
   useEffect(() => {
     if (matchMode !== "online" || typeof window === "undefined") {
@@ -633,7 +688,6 @@ export function App() {
 
     const handleOnline = () => {
       setIsOffline(false);
-      pollingFailureCountRef.current = 0;
       setNetworkBannerMessage("ネットワークに再接続しました。同期を再試行します。");
 
       if (screenMode === "game" && onlineGameId && !gameOver) {
@@ -1028,7 +1082,6 @@ export function App() {
 
     const synced = await syncSnapshot(onlineGameId, { showDialog: false });
     if (synced) {
-      pollingFailureCountRef.current = 0;
       setNetworkBannerMessage(null);
       setGameMessage(null);
     }

--- a/app/src/online/realtimeEvents.ts
+++ b/app/src/online/realtimeEvents.ts
@@ -1,0 +1,68 @@
+import type { GameSnapshot } from "./gameApi";
+
+const EVENT_PATH_PREFIX = "/api/games";
+const SNAPSHOT_EVENT_TYPES = new Set(["game.updated", "game.finished"]);
+
+type RealtimeEnvelope = {
+  type?: unknown;
+  payload?: unknown;
+};
+
+function normalizeBaseUrl(baseUrl?: string): string {
+  const envBase = typeof import.meta !== "undefined" ? (import.meta.env?.VITE_API_BASE_URL as string | undefined) : undefined;
+  const selected = baseUrl ?? envBase ?? "";
+  return selected.endsWith("/") ? selected.slice(0, -1) : selected;
+}
+
+function toWebSocketBaseUrl(baseUrl: string): string {
+  if (baseUrl.startsWith("https://")) {
+    return `wss://${baseUrl.slice("https://".length)}`;
+  }
+  if (baseUrl.startsWith("http://")) {
+    return `ws://${baseUrl.slice("http://".length)}`;
+  }
+  return baseUrl;
+}
+
+function isGameSnapshot(value: unknown): value is GameSnapshot {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<GameSnapshot>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.version === "number" &&
+    typeof candidate.status === "string" &&
+    typeof candidate.turn === "string" &&
+    candidate.state !== undefined
+  );
+}
+
+export function buildGameEventsWebSocketUrl(gameId: string, baseUrl?: string): string {
+  const path = `${EVENT_PATH_PREFIX}/${encodeURIComponent(gameId)}/events`;
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (!normalized) {
+    return path;
+  }
+  return `${toWebSocketBaseUrl(normalized)}${path}`;
+}
+
+export function parseRealtimeSnapshotMessage(rawData: unknown): GameSnapshot | null {
+  if (typeof rawData !== "string") {
+    return null;
+  }
+
+  let parsed: RealtimeEnvelope;
+  try {
+    parsed = JSON.parse(rawData) as RealtimeEnvelope;
+  } catch {
+    return null;
+  }
+
+  if (!SNAPSHOT_EVENT_TYPES.has(String(parsed.type))) {
+    return null;
+  }
+
+  return isGameSnapshot(parsed.payload) ? parsed.payload : null;
+}

--- a/app/tests/realtimeEvents.test.ts
+++ b/app/tests/realtimeEvents.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import { buildGameEventsWebSocketUrl, parseRealtimeSnapshotMessage } from "../src/online/realtimeEvents";
+import type { GameSnapshot } from "../src/online/gameApi";
+
+function createSnapshot(partial: Partial<GameSnapshot> = {}): GameSnapshot {
+  return {
+    id: "game-1",
+    status: "active",
+    turn: "black",
+    state: {
+      board: [],
+      hands: { black: {}, white: {} },
+      turn: "black",
+    } as GameSnapshot["state"],
+    mainSecondsBlack: 300,
+    mainSecondsWhite: 300,
+    byoSecondsBlack: 30,
+    byoSecondsWhite: 30,
+    resultType: null,
+    winner: null,
+    version: 2,
+    turnStartedAtMs: 1_000,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    ...partial,
+  };
+}
+
+describe("realtimeEvents", () => {
+  test("builds websocket url from http base", () => {
+    expect(buildGameEventsWebSocketUrl("game-1", "http://127.0.0.1:3000/")).toBe(
+      "ws://127.0.0.1:3000/api/games/game-1/events",
+    );
+  });
+
+  test("builds websocket url from https base", () => {
+    expect(buildGameEventsWebSocketUrl("game-1", "https://example.com")).toBe(
+      "wss://example.com/api/games/game-1/events",
+    );
+  });
+
+  test("parses game.updated snapshot message", () => {
+    const snapshot = createSnapshot({ version: 5 });
+    const raw = JSON.stringify({ type: "game.updated", payload: snapshot });
+    expect(parseRealtimeSnapshotMessage(raw)).toEqual(snapshot);
+  });
+
+  test("ignores messages that are not snapshot updates", () => {
+    const joined = JSON.stringify({ type: "player.joined", payload: { seat: "black" } });
+    expect(parseRealtimeSnapshotMessage(joined)).toBeNull();
+    expect(parseRealtimeSnapshotMessage("{invalid-json")).toBeNull();
+  });
+});

--- a/server/tests/realtimeEvents.test.ts
+++ b/server/tests/realtimeEvents.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import type { AddressInfo } from "node:net";
+import { WebSocket } from "ws";
+import { createApp } from "../src/app";
+
+const app = createApp();
+let baseUrl = "";
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    app.listen(0, () => {
+      const address = app.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    app.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+function waitForOpen(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onOpen = () => {
+      socket.off("error", onError);
+      resolve();
+    };
+    const onError = (error: Error) => {
+      socket.off("open", onOpen);
+      reject(error);
+    };
+    socket.once("open", onOpen);
+    socket.once("error", onError);
+  });
+}
+
+function waitForMessage(socket: WebSocket, timeoutMs = 3000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      socket.off("message", onMessage);
+      reject(new Error("websocket message timeout"));
+    }, timeoutMs);
+
+    const onMessage = (raw: WebSocket.RawData) => {
+      clearTimeout(timeoutId);
+      const text = typeof raw === "string" ? raw : raw.toString("utf8");
+      resolve(text);
+    };
+
+    socket.once("message", onMessage);
+  });
+}
+
+describe("realtime websocket events", () => {
+  test("broadcasts game.updated snapshot after move", async () => {
+    const createRes = await fetch(`${baseUrl}/api/games`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mainMinutes: 5, byoSeconds: 30 }),
+    });
+    expect(createRes.status).toBe(201);
+    const created = (await createRes.json()) as { gameId: string; joinToken: string };
+
+    const blackJoinRes = await fetch(`${baseUrl}/api/games/${created.gameId}/join`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "black", seat: "black", joinToken: created.joinToken }),
+    });
+    expect(blackJoinRes.status).toBe(200);
+    const blackJoin = (await blackJoinRes.json()) as { sessionToken: string };
+
+    const whiteJoinRes = await fetch(`${baseUrl}/api/games/${created.gameId}/join`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "white", seat: "white", joinToken: created.joinToken }),
+    });
+    expect(whiteJoinRes.status).toBe(200);
+
+    const wsUrl = baseUrl.replace("http://", "ws://");
+    const socket = new WebSocket(`${wsUrl}/api/games/${created.gameId}/events`);
+    await waitForOpen(socket);
+
+    const snapshotRes = await fetch(`${baseUrl}/api/games/${created.gameId}`);
+    expect(snapshotRes.status).toBe(200);
+    const snapshot = (await snapshotRes.json()) as { version: number };
+
+    const moveRes = await fetch(`${baseUrl}/api/games/${created.gameId}/moves`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${blackJoin.sessionToken}`,
+      },
+      body: JSON.stringify({
+        expectedVersion: snapshot.version,
+        move: { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },
+      }),
+    });
+    expect(moveRes.status).toBe(200);
+
+    const event = JSON.parse(await waitForMessage(socket)) as {
+      type: string;
+      payload: { id: string; version: number };
+    };
+
+    expect(event.type).toBe("game.updated");
+    expect(event.payload.id).toBe(created.gameId);
+    expect(event.payload.version).toBe(snapshot.version + 1);
+
+    socket.close();
+  });
+});


### PR DESCRIPTION
## 概要
- 対局中の主同期経路をポーリングから WebSocket イベント駆動へ変更
- 切断時の再接続（バックオフ）と再同期処理を追加
- 観戦モードを含むリアルタイム反映を統一
- クライアント/サーバ双方にリアルタイム同期テストを追加

## 変更ファイル
- app/src/App.tsx
- app/src/online/realtimeEvents.ts
- app/tests/realtimeEvents.test.ts
- server/tests/realtimeEvents.test.ts

## 動作確認
- npm run test
- npm run build