### PR TITLE
Issue #72 ロビーを合言葉マッチング方式へ統一

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -9,20 +9,19 @@ import { type BoardMove, type Color, type GameState, type Move, type PieceKind, 
 import { PIECE_SOUND_PATH } from "./assets";
 import { formatMoveText, oppositeColor, sideLabel, winnerLabel } from "./game/moveText";
 import { positionToKey } from "./game/position";
-import { createClockState, DEFAULT_TIME_CONTROL, formatClockText, normalizeTimeControl, type ClockState, type TimeControl } from "./game/timeControl";
+import { createClockState, DEFAULT_TIME_CONTROL, formatClockText, type ClockState } from "./game/timeControl";
 import { canOperateTurn, getTurnLockMessage } from "./game/turnControl";
 import {
   ApiClientError,
-  createGame,
   getGameSnapshot,
   getSessionPlayer,
-  joinGame,
+  matchLobby,
   resignGame,
   submitMove,
   type GameSnapshot,
 } from "./online/gameApi";
 import { buildResultText, toClockState } from "./online/gameSnapshot";
-import { formatLobbyError, validateCreateGameForm, validateJoinGameForm, validateSpectateGameForm } from "./online/lobbyValidation";
+import { formatLobbyError, validateMatchLobbyForm, validateSpectateGameForm } from "./online/lobbyValidation";
 import { getPollingIntervalMs, shouldApplySnapshot } from "./online/pollingPolicy";
 import { computePollingRetryDelayMs, isRetryableNetworkError } from "./online/networkRecovery";
 import { clearStoredSession, loadStoredSession, saveStoredSession } from "./online/sessionPersistence";
@@ -68,30 +67,22 @@ export function App() {
   const [screenMode, setScreenMode] = useState<ScreenMode>("setup");
   const [setupMode, setSetupMode] = useState<MatchMode>("online");
   const [matchMode, setMatchMode] = useState<MatchMode>("online");
-  const [createMainMinutes, setCreateMainMinutes] = useState<string>(String(Math.floor(initialTimeControl.mainSeconds / 60)));
-  const [createByoSeconds, setCreateByoSeconds] = useState<string>(String(initialTimeControl.byoSeconds));
-  const [joinGameId, setJoinGameId] = useState<string>("");
+  const [passphrase, setPassphrase] = useState<string>("");
   const [spectateGameId, setSpectateGameId] = useState<string>(initialSpectateGameId ?? "");
-  const [joinToken, setJoinToken] = useState<string>("");
   const [joinName, setJoinName] = useState<string>("");
-  const [joinSeat, setJoinSeat] = useState<Color>("black");
   const [botName, setBotName] = useState<string>("player");
   const [botSeat, setBotSeat] = useState<Color>("black");
-  const [createErrors, setCreateErrors] = useState<string[]>([]);
   const [joinErrors, setJoinErrors] = useState<string[]>([]);
   const [spectateErrors, setSpectateErrors] = useState<string[]>([]);
-  const [createMessage, setCreateMessage] = useState<string | null>(null);
   const [joinMessage, setJoinMessage] = useState<string | null>(null);
   const [spectateMessage, setSpectateMessage] = useState<string | null>(null);
   const [botMessage, setBotMessage] = useState<string | null>(null);
-  const [isCreating, setIsCreating] = useState(false);
   const [isJoining, setIsJoining] = useState(false);
   const [isStartingSpectate, setIsStartingSpectate] = useState(false);
   const [isStartingBot, setIsStartingBot] = useState(false);
   const [isRestoringSession, setIsRestoringSession] = useState(false);
   const [session, setSession] = useState<SessionState | null>(null);
   const [spectatorGameId, setSpectatorGameId] = useState<string | null>(null);
-  const [timeControl, setTimeControl] = useState<TimeControl>(initialTimeControl);
 
   const [state, setState] = useState<GameState>(initialState);
   const [clockState, setClockState] = useState<ClockState>(() => createClockState(initialTimeControl));
@@ -140,10 +131,8 @@ export function App() {
 
   const onSetupModeChange = useCallback((mode: MatchMode) => {
     setSetupMode(mode);
-    setCreateErrors([]);
     setJoinErrors([]);
     setSpectateErrors([]);
-    setCreateMessage(null);
     setJoinMessage(null);
     setSpectateMessage(null);
     setBotMessage(null);
@@ -165,12 +154,12 @@ export function App() {
       return null;
     }
 
-    const sourceGameId = joinGameId.trim() || spectateGameId.trim();
+    const sourceGameId = spectateGameId.trim();
     if (!sourceGameId) {
       return null;
     }
     return buildSpectatorUrl(window.location.origin, window.location.pathname, sourceGameId);
-  }, [joinGameId, spectateGameId]);
+  }, [spectateGameId]);
 
   const setNetworkBannerFromError = useCallback((error: unknown) => {
     if (!isRetryableNetworkError(error)) {
@@ -300,9 +289,7 @@ export function App() {
       }
 
       setIsRestoringSession(true);
-      setJoinGameId(stored.gameId);
       setJoinName(stored.displayName);
-      setJoinSeat(stored.seat);
       setJoinMessage("前回対局を復元中です...");
 
       try {
@@ -372,42 +359,10 @@ export function App() {
     };
   }, [initialSpectateGameId, replaceSpectateLocation, syncSnapshot]);
 
-  const onCreateGame = useCallback(async () => {
-    const validated = validateCreateGameForm({ mainMinutes: createMainMinutes, byoSeconds: createByoSeconds });
-    if (!validated.ok) {
-      setCreateErrors(validated.errors);
-      setCreateMessage(null);
-      return;
-    }
-
-    setCreateErrors([]);
-    setCreateMessage(null);
-    setIsCreating(true);
-    try {
-      const created = await createGame(validated.value);
-      setJoinGameId(created.gameId);
-      setJoinToken(created.joinToken);
-      setCreateMessage(`対局を作成しました。gameId: ${created.gameId}`);
-      setTimeControl(normalizeTimeControl(validated.value.mainMinutes, validated.value.byoSeconds));
-      setNetworkBannerMessage(null);
-    } catch (error) {
-      setNetworkBannerFromError(error);
-      if (error instanceof ApiClientError) {
-        setCreateMessage(formatLobbyError(error));
-      } else {
-        setCreateMessage("対局作成に失敗しました。時間をおいて再試行してください。");
-      }
-    } finally {
-      setIsCreating(false);
-    }
-  }, [createMainMinutes, createByoSeconds, setNetworkBannerFromError]);
-
   const onJoinGame = useCallback(async () => {
-    const validated = validateJoinGameForm({
-      gameId: joinGameId,
-      joinToken,
+    const validated = validateMatchLobbyForm({
+      passphrase,
       name: joinName,
-      seat: joinSeat,
     });
     if (!validated.ok) {
       setJoinErrors(validated.errors);
@@ -419,9 +374,9 @@ export function App() {
     setJoinMessage(null);
     setIsJoining(true);
     try {
-      const joined = await joinGame(validated.value);
+      const joined = await matchLobby(validated.value);
       const nextSession: SessionState = {
-        gameId: validated.value.gameId,
+        gameId: joined.gameId,
         seat: joined.seat,
         displayName: validated.value.name,
         sessionToken: joined.sessionToken,
@@ -447,7 +402,7 @@ export function App() {
     } finally {
       setIsJoining(false);
     }
-  }, [joinGameId, joinToken, joinName, joinSeat, replaceSpectateLocation, syncSnapshot, setNetworkBannerFromError]);
+  }, [passphrase, joinName, replaceSpectateLocation, syncSnapshot, setNetworkBannerFromError]);
 
   const startSpectatingByGameId = useCallback(async (gameId: string): Promise<boolean> => {
     setIsStartingSpectate(true);
@@ -1038,39 +993,27 @@ export function App() {
     return (
       <SetupScreen
         setupMode={setupMode}
-        createMainMinutes={createMainMinutes}
-        createByoSeconds={createByoSeconds}
-        joinGameId={joinGameId}
+        passphrase={passphrase}
         spectateGameId={spectateGameId}
-        joinToken={joinToken}
         joinName={joinName}
-        joinSeat={joinSeat}
         botName={botName}
         botSeat={botSeat}
-        createErrors={createErrors}
         joinErrors={joinErrors}
         spectateErrors={spectateErrors}
-        createMessage={createMessage}
         joinMessage={joinMessage}
         spectateMessage={spectateMessage}
         botMessage={botMessage}
         spectatorUrl={spectatorUrl}
-        isCreating={isCreating}
         isJoining={isJoining || isRestoringSession}
         isStartingSpectate={isStartingSpectate}
         isStartingBot={isStartingBot}
         onSetupModeChange={onSetupModeChange}
-        onCreateMainMinutesChange={setCreateMainMinutes}
-        onCreateByoSecondsChange={setCreateByoSeconds}
-        onJoinGameIdChange={setJoinGameId}
+        onPassphraseChange={setPassphrase}
         onSpectateGameIdChange={setSpectateGameId}
-        onJoinTokenChange={setJoinToken}
         onJoinNameChange={setJoinName}
-        onJoinSeatChange={setJoinSeat}
         onBotNameChange={setBotName}
         onBotSeatChange={setBotSeat}
         onBotStart={onStartBotGame}
-        onCreateSubmit={onCreateGame}
         onJoinSubmit={onJoinGame}
         onSpectateSubmit={() => {
           void onStartSpectate();
@@ -1231,5 +1174,3 @@ export function App() {
     </main>
   );
 }
-
-

--- a/app/src/online/gameApi.ts
+++ b/app/src/online/gameApi.ts
@@ -28,6 +28,19 @@ export type JoinGameResponse = {
   seat: Seat;
 };
 
+export type MatchLobbyRequest = {
+  passphrase: string;
+  name: string;
+};
+
+export type MatchLobbyResponse = {
+  gameId: string;
+  guestId: string;
+  sessionToken: string;
+  managedToken: string | null;
+  seat: Seat;
+};
+
 export type GameSnapshot = {
   id: string;
   status: GameStatus;
@@ -165,6 +178,17 @@ export async function joinGame(input: JoinGameRequest, baseUrl?: string): Promis
       name: input.name,
       seat: input.seat,
       joinToken: input.joinToken,
+    }),
+  });
+}
+
+export async function matchLobby(input: MatchLobbyRequest, baseUrl?: string): Promise<MatchLobbyResponse> {
+  return requestApiJson<MatchLobbyResponse>("/api/lobby/match", baseUrl, {
+    method: "POST",
+    headers: buildJsonHeaders(),
+    body: JSON.stringify({
+      passphrase: input.passphrase,
+      name: input.name,
     }),
   });
 }

--- a/app/src/online/lobbyValidation.ts
+++ b/app/src/online/lobbyValidation.ts
@@ -1,5 +1,7 @@
 type Seat = "black" | "white";
 
+const PASS_PHRASE_PATTERN = /^[A-Za-z0-9]{1,8}$/;
+
 export type CreateGameFormInput = {
   mainMinutes: string;
   byoSeconds: string;
@@ -10,6 +12,11 @@ export type JoinGameFormInput = {
   joinToken: string;
   name: string;
   seat: Seat;
+};
+
+export type MatchLobbyFormInput = {
+  passphrase: string;
+  name: string;
 };
 
 export type SpectateGameFormInput = {
@@ -36,6 +43,11 @@ function toInteger(value: string): number | null {
   return Number.isInteger(parsed) ? parsed : null;
 }
 
+function hasValidName(name: string): boolean {
+  const trimmed = name.trim();
+  return trimmed.length >= 2 && trimmed.length <= 20;
+}
+
 export function validateCreateGameForm(input: CreateGameFormInput): ValidationResult<{ mainMinutes: number; byoSeconds: number }> {
   const errors: string[] = [];
   const mainMinutes = toInteger(input.mainMinutes);
@@ -55,8 +67,8 @@ export function validateCreateGameForm(input: CreateGameFormInput): ValidationRe
   return {
     ok: true,
     value: {
-      mainMinutes: mainMinutes as number,
-      byoSeconds: byoSeconds as number,
+      mainMinutes,
+      byoSeconds,
     },
   };
 }
@@ -75,7 +87,7 @@ export function validateJoinGameForm(
   if (!joinToken) {
     errors.push("joinTokenを入力してください。");
   }
-  if (name.length < 2 || name.length > 20) {
+  if (!hasValidName(name)) {
     errors.push("表示名は2〜20文字で入力してください。");
   }
 
@@ -90,6 +102,34 @@ export function validateJoinGameForm(
       joinToken,
       name,
       seat: input.seat,
+    },
+  };
+}
+
+export function validateMatchLobbyForm(input: MatchLobbyFormInput): ValidationResult<{ passphrase: string; name: string }> {
+  const errors: string[] = [];
+  const passphrase = input.passphrase.trim();
+  const name = input.name.trim();
+
+  if (!passphrase) {
+    errors.push("合言葉を入力してください。");
+  } else if (!PASS_PHRASE_PATTERN.test(passphrase)) {
+    errors.push("合言葉は半角英数字8文字以内で入力してください。");
+  }
+
+  if (!hasValidName(name)) {
+    errors.push("表示名は2〜20文字で入力してください。");
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    value: {
+      passphrase,
+      name,
     },
   };
 }
@@ -123,7 +163,8 @@ type LobbyErrorInput = {
 export function formatLobbyError(error: LobbyErrorInput): string {
   const byCode: Record<string, string> = {
     NETWORK_ERROR: "通信に失敗しました。ネットワーク状態を確認してください。",
-    INVALID_CREATE_GAME_PAYLOAD: "作成フォームの入力値が不正です。",
+    INVALID_CREATE_GAME_PAYLOAD: "対局作成フォームの入力値が不正です。",
+    INVALID_MATCH_PAYLOAD: "合言葉または表示名の入力値が不正です。",
     GAME_NOT_FOUND: "指定された対局が見つかりません。gameIdを確認してください。",
     INVALID_JOIN_TOKEN: "参加トークンが無効です。入力内容を確認してください。",
     GAME_IS_FULL: "この対局はすでに満席です。",
@@ -138,7 +179,7 @@ export function formatLobbyError(error: LobbyErrorInput): string {
     return "サーバーでエラーが発生しました。時間をおいて再試行してください。";
   }
   if (error.status >= 400) {
-    return error.message || "入力内容を確認してください。";
+    return error.message || "入力値を確認してください。";
   }
-  return "不明なエラーが発生しました。";
+  return "予期しないエラーが発生しました。";
 }

--- a/app/src/ui/SetupScreen.tsx
+++ b/app/src/ui/SetupScreen.tsx
@@ -4,78 +4,54 @@ type SetupMatchMode = "online" | "bot";
 
 type SetupScreenProps = {
   setupMode: SetupMatchMode;
-  createMainMinutes: string;
-  createByoSeconds: string;
-  joinGameId: string;
+  passphrase: string;
   spectateGameId: string;
-  joinToken: string;
   joinName: string;
-  joinSeat: Color;
-  createErrors: string[];
   joinErrors: string[];
   spectateErrors: string[];
-  createMessage: string | null;
   joinMessage: string | null;
   spectateMessage: string | null;
   botMessage: string | null;
   spectatorUrl: string | null;
-  isCreating: boolean;
   isJoining: boolean;
   isStartingSpectate: boolean;
   isStartingBot: boolean;
   botName: string;
   botSeat: Color;
   onSetupModeChange: (mode: SetupMatchMode) => void;
-  onCreateMainMinutesChange: (value: string) => void;
-  onCreateByoSecondsChange: (value: string) => void;
-  onJoinGameIdChange: (value: string) => void;
+  onPassphraseChange: (value: string) => void;
   onSpectateGameIdChange: (value: string) => void;
-  onJoinTokenChange: (value: string) => void;
   onJoinNameChange: (value: string) => void;
-  onJoinSeatChange: (seat: Color) => void;
   onBotNameChange: (value: string) => void;
   onBotSeatChange: (seat: Color) => void;
   onBotStart: () => void;
-  onCreateSubmit: () => void;
   onJoinSubmit: () => void;
   onSpectateSubmit: () => void;
 };
 
 export function SetupScreen({
   setupMode,
-  createMainMinutes,
-  createByoSeconds,
-  joinGameId,
+  passphrase,
   spectateGameId,
-  joinToken,
   joinName,
-  joinSeat,
-  createErrors,
   joinErrors,
   spectateErrors,
-  createMessage,
   joinMessage,
   spectateMessage,
   botMessage,
   spectatorUrl,
-  isCreating,
   isJoining,
   isStartingSpectate,
   isStartingBot,
   botName,
   botSeat,
   onSetupModeChange,
-  onCreateMainMinutesChange,
-  onCreateByoSecondsChange,
-  onJoinGameIdChange,
+  onPassphraseChange,
   onSpectateGameIdChange,
-  onJoinTokenChange,
   onJoinNameChange,
-  onJoinSeatChange,
   onBotNameChange,
   onBotSeatChange,
   onBotStart,
-  onCreateSubmit,
   onJoinSubmit,
   onSpectateSubmit,
 }: SetupScreenProps) {
@@ -83,7 +59,7 @@ export function SetupScreen({
     <main className="app">
       <h1>Shogi Game</h1>
       <section className="start-screen" aria-label="match setup">
-        <h2>{setupMode === "online" ? "オンライン対局の作成 / 参加" : "Bot対戦を開始"}</h2>
+        <h2>{setupMode === "online" ? "オンライン対局" : "Bot対局"}</h2>
         <div className="setup-options" aria-label="match mode toggle">
           <button
             type="button"
@@ -97,75 +73,25 @@ export function SetupScreen({
             className={`setup-button ${setupMode === "bot" ? "is-selected" : ""}`.trim()}
             onClick={() => onSetupModeChange("bot")}
           >
-            Bot対戦
+            Bot対局
           </button>
         </div>
 
         {setupMode === "online" ? (
           <div className="lobby-columns">
-            <section className="lobby-card" aria-label="create game form">
-              <h3>対局を作成</h3>
+            <section className="lobby-card" aria-label="match by passphrase form">
+              <h3>合言葉マッチング</h3>
               <div className="setup-input-grid">
-                <label className="setup-input-label" htmlFor="create-main-minutes-input">
-                  持ち時間 (分)
+                <label className="setup-input-label" htmlFor="match-passphrase-input">
+                  合言葉
                 </label>
                 <input
-                  id="create-main-minutes-input"
-                  className="setup-number-input"
-                  type="number"
-                  min={1}
-                  step={1}
-                  value={createMainMinutes}
-                  onChange={(event) => onCreateMainMinutesChange(event.target.value)}
-                />
-                <label className="setup-input-label" htmlFor="create-byo-seconds-input">
-                  秒読み (秒)
-                </label>
-                <input
-                  id="create-byo-seconds-input"
-                  className="setup-number-input"
-                  type="number"
-                  min={0}
-                  step={10}
-                  value={createByoSeconds}
-                  onChange={(event) => onCreateByoSecondsChange(event.target.value)}
-                />
-              </div>
-              {createErrors.length > 0 ? (
-                <ul className="form-error-list" aria-label="create validation errors">
-                  {createErrors.map((error) => (
-                    <li key={error}>{error}</li>
-                  ))}
-                </ul>
-              ) : null}
-              {createMessage ? <p className="form-message">{createMessage}</p> : null}
-              <button type="button" className="start-match-button" onClick={onCreateSubmit} disabled={isCreating}>
-                {isCreating ? "作成中..." : "対局を作成"}
-              </button>
-            </section>
-
-            <section className="lobby-card" aria-label="join game form">
-              <h3>対局に参加</h3>
-              <div className="setup-input-grid">
-                <label className="setup-input-label" htmlFor="join-game-id-input">
-                  gameId
-                </label>
-                <input
-                  id="join-game-id-input"
+                  id="match-passphrase-input"
                   className="setup-number-input"
                   type="text"
-                  value={joinGameId}
-                  onChange={(event) => onJoinGameIdChange(event.target.value)}
-                />
-                <label className="setup-input-label" htmlFor="join-token-input">
-                  joinToken
-                </label>
-                <input
-                  id="join-token-input"
-                  className="setup-number-input"
-                  type="text"
-                  value={joinToken}
-                  onChange={(event) => onJoinTokenChange(event.target.value)}
+                  maxLength={8}
+                  value={passphrase}
+                  onChange={(event) => onPassphraseChange(event.target.value)}
                 />
                 <label className="setup-input-label" htmlFor="join-name-input">
                   表示名
@@ -177,23 +103,6 @@ export function SetupScreen({
                   value={joinName}
                   onChange={(event) => onJoinNameChange(event.target.value)}
                 />
-                <span className="setup-input-label">席</span>
-                <div className="setup-options">
-                  <button
-                    type="button"
-                    className={`setup-button ${joinSeat === "black" ? "is-selected" : ""}`.trim()}
-                    onClick={() => onJoinSeatChange("black")}
-                  >
-                    black
-                  </button>
-                  <button
-                    type="button"
-                    className={`setup-button ${joinSeat === "white" ? "is-selected" : ""}`.trim()}
-                    onClick={() => onJoinSeatChange("white")}
-                  >
-                    white
-                  </button>
-                </div>
               </div>
               {joinErrors.length > 0 ? (
                 <ul className="form-error-list" aria-label="join validation errors">
@@ -204,7 +113,7 @@ export function SetupScreen({
               ) : null}
               {joinMessage ? <p className="form-message">{joinMessage}</p> : null}
               <button type="button" className="start-match-button" onClick={onJoinSubmit} disabled={isJoining}>
-                {isJoining ? "参加中..." : "対局に参加"}
+                {isJoining ? "接続中..." : "マッチング開始"}
               </button>
             </section>
 
@@ -237,7 +146,7 @@ export function SetupScreen({
                 onClick={onSpectateSubmit}
                 disabled={isStartingSpectate}
               >
-                {isStartingSpectate ? "接続中..." : "観戦を開始"}
+                {isStartingSpectate ? "開始中..." : "観戦を開始"}
               </button>
             </section>
           </div>
@@ -275,7 +184,7 @@ export function SetupScreen({
             </div>
             {botMessage ? <p className="form-message">{botMessage}</p> : null}
             <button type="button" className="start-match-button" onClick={onBotStart} disabled={isStartingBot}>
-              {isStartingBot ? "開始中..." : "Bot対戦を開始"}
+              {isStartingBot ? "開始中..." : "Bot対局を開始"}
             </button>
           </section>
         )}

--- a/app/tests/gameApi.test.ts
+++ b/app/tests/gameApi.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { ApiClientError, createGame, getGameSnapshot, getSessionPlayer, joinGame, resignGame, submitMove } from "../src/online/gameApi";
+import { ApiClientError, createGame, getGameSnapshot, getSessionPlayer, joinGame, matchLobby, resignGame, submitMove } from "../src/online/gameApi";
 
 const originalFetch = global.fetch;
 
@@ -69,6 +69,52 @@ describe("gameApi", () => {
         method: "POST",
       }),
     );
+  });
+
+  test("matchLobby sends POST /api/lobby/match and returns payload", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          gameId: "game-1",
+          guestId: "guest-1",
+          sessionToken: "session-1",
+          managedToken: null,
+          seat: "black",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await matchLobby(
+      {
+        passphrase: "Room123",
+        name: "player-1",
+      },
+      "http://127.0.0.1:3000",
+    );
+
+    expect(result).toEqual({
+      gameId: "game-1",
+      guestId: "guest-1",
+      sessionToken: "session-1",
+      managedToken: null,
+      seat: "black",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:3000/api/lobby/match",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    expect(JSON.parse((fetchMock.mock.calls[0]?.[1] as { body: string }).body)).toEqual({
+      passphrase: "Room123",
+      name: "player-1",
+    });
   });
 
   test("throws ApiClientError with code/status for failed response", async () => {

--- a/app/tests/onlineLobby.test.ts
+++ b/app/tests/onlineLobby.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { formatLobbyError, validateCreateGameForm, validateJoinGameForm, validateSpectateGameForm } from "../src/online/lobbyValidation";
+import { formatLobbyError, validateCreateGameForm, validateMatchLobbyForm, validateSpectateGameForm } from "../src/online/lobbyValidation";
 
 describe("lobby validation", () => {
   test("validateCreateGameForm returns errors for invalid values", () => {
@@ -23,38 +23,45 @@ describe("lobby validation", () => {
     });
   });
 
-  test("validateJoinGameForm returns errors when required fields are empty", () => {
-    const result = validateJoinGameForm({
-      gameId: "",
-      joinToken: "",
+  test("validateMatchLobbyForm returns errors when required fields are invalid", () => {
+    const result = validateMatchLobbyForm({
+      passphrase: "",
       name: "a",
-      seat: "black",
     });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
     }
-    expect(result.errors).toContain("gameIdを入力してください。");
-    expect(result.errors).toContain("joinTokenを入力してください。");
+    expect(result.errors).toContain("合言葉を入力してください。");
     expect(result.errors).toContain("表示名は2〜20文字で入力してください。");
   });
 
-  test("validateJoinGameForm trims and accepts valid input", () => {
-    const result = validateJoinGameForm({
-      gameId: "12ab",
-      joinToken: "f".repeat(32),
+  test("validateMatchLobbyForm trims and accepts valid input", () => {
+    const result = validateMatchLobbyForm({
+      passphrase: " Room123 ",
       name: "  player-1  ",
-      seat: "white",
     });
     expect(result).toEqual({
       ok: true,
       value: {
-        gameId: "12ab",
-        joinToken: "f".repeat(32),
+        passphrase: "Room123",
         name: "player-1",
-        seat: "white",
       },
     });
+  });
+
+  test("validateMatchLobbyForm rejects non-alphanumeric passphrase and long passphrase", () => {
+    const invalidChars = validateMatchLobbyForm({ passphrase: "abc-123", name: "player-1" });
+    expect(invalidChars.ok).toBe(false);
+    if (!invalidChars.ok) {
+      expect(invalidChars.errors).toContain("合言葉は半角英数字8文字以内で入力してください。");
+    }
+
+    const invalidLength = validateMatchLobbyForm({ passphrase: "abcdefghi", name: "player-1" });
+    expect(invalidLength.ok).toBe(false);
+    if (!invalidLength.ok) {
+      expect(invalidLength.errors).toContain("合言葉は半角英数字8文字以内で入力してください。");
+    }
   });
 
   test("validateSpectateGameForm returns error when gameId is empty", () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,10 +6,10 @@ import { requireSessionAuth } from "./middleware";
 import { RateLimiter } from "./rateLimiter";
 import { RealtimeHub } from "./realtime";
 import { respond, respondError } from "./respond";
-import { ROUTE_JOIN, ROUTE_ME, ROUTE_MOVE, ROUTE_RECORDS, ROUTE_RESIGN, ROUTE_SNAPSHOT } from "./routePatterns";
+import { ROUTE_JOIN, ROUTE_LOBBY_MATCH, ROUTE_ME, ROUTE_MOVE, ROUTE_RECORDS, ROUTE_RESIGN, ROUTE_SNAPSHOT } from "./routePatterns";
 import { createDefaultStore, type GameStore } from "./store";
 import type { Player } from "./types";
-import { isMoveRequestBody, isValidCreateGameInput, isValidJoinGameInput } from "./validators";
+import { isMoveRequestBody, isValidCreateGameInput, isValidJoinGameInput, isValidLobbyMatchInput } from "./validators";
 
 type AppOptions = {
   store?: GameStore;
@@ -128,6 +128,20 @@ async function handleRequest(
     const created = await store.createGame(body);
     respond(res, ctx, 201, created, { gameId: created.gameId, event: "game.created" });
     realtime.broadcast(created.gameId, "game.created", created);
+    return;
+  }
+
+  const lobbyMatch = req.url?.match(ROUTE_LOBBY_MATCH);
+  if (req.method === "POST" && lobbyMatch) {
+    const body = await readJsonBody<unknown>(req);
+    if (!isValidLobbyMatchInput(body)) {
+      respondError(res, ctx, 400, "INVALID_MATCH_PAYLOAD", "Invalid lobby match payload");
+      return;
+    }
+
+    const matched = await store.matchByPassphrase(body);
+    respond(res, ctx, 200, matched, { gameId: matched.gameId, guestId: matched.guestId, event: "lobby.matched" });
+    realtime.broadcast(matched.gameId, "player.joined", matched);
     return;
   }
 

--- a/server/src/routePatterns.ts
+++ b/server/src/routePatterns.ts
@@ -1,3 +1,4 @@
+export const ROUTE_LOBBY_MATCH = /^\/api\/lobby\/match$/;
 export const ROUTE_JOIN = /^\/api\/games\/([^/]+)\/join$/;
 export const ROUTE_RECORDS = /^\/api\/games\/([^/]+)\/records$/;
 export const ROUTE_SNAPSHOT = /^\/api\/games\/([^/]+)$/;

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -8,7 +8,7 @@ import { applyMove } from "../../core/src/applyMove";
 import { createInitialGameState } from "../../core/src/initialPosition";
 import { createSessionToken, hashToken } from "./auth";
 import { issueManagedAuthToken } from "./managedAuth";
-import type { CreateGameInput, Game, JoinGameInput, MoveRecord, Player, Seat } from "./types";
+import type { CreateGameInput, Game, JoinGameInput, LobbyMatchInput, LobbyMatchResult, MoveRecord, Player, Seat } from "./types";
 
 type DbQueryResult<T> = {
   rows: T[];
@@ -94,6 +94,7 @@ export interface GameStore {
     managedToken: string | null;
     seat: Seat;
   }>;
+  matchByPassphrase(input: LobbyMatchInput): Promise<LobbyMatchResult>;
   findPlayerBySessionToken(gameId: string, tokenHash: string): Promise<Player | null>;
   findPlayerByGuestId(gameId: string, guestId: string): Promise<Player | null>;
   getGame(gameId: string): Promise<Game | null>;
@@ -102,6 +103,9 @@ export interface GameStore {
   getMoves(gameId: string): Promise<MoveRecord[]>;
   close?(): Promise<void>;
 }
+
+const DEFAULT_MATCH_MAIN_MINUTES = 10;
+const DEFAULT_MATCH_BYO_SECONDS = 30;
 
 function toIsoNow(): string {
   return new Date().toISOString();
@@ -134,6 +138,16 @@ function splitSqlStatements(script: string): string[] {
 
 function createJoinToken(): string {
   return randomUUID().replaceAll("-", "");
+}
+
+function pickAvailableSeat(seats: readonly Seat[]): Seat | null {
+  if (!seats.includes("black")) {
+    return "black";
+  }
+  if (!seats.includes("white")) {
+    return "white";
+  }
+  return null;
 }
 
 function oppositeSeat(seat: Seat): Seat {
@@ -266,6 +280,7 @@ export class InMemoryStore implements GameStore {
   private readonly joinTokens = new Map<string, string>();
   private readonly playersByGame = new Map<string, Player[]>();
   private readonly movesByGame = new Map<string, MoveRecord[]>();
+  private readonly passphrasesByGame = new Map<string, string>();
 
   private settleTimeoutIfNeeded(game: Game): void {
     const snapshot: PersistedGame = {
@@ -383,6 +398,70 @@ export class InMemoryStore implements GameStore {
       sessionToken,
       managedToken: issueManagedAuthToken(guestId),
       seat: input.seat,
+    };
+  }
+
+  async matchByPassphrase(input: LobbyMatchInput): Promise<LobbyMatchResult> {
+    const passphrase = input.passphrase.trim();
+    const normalizedName = input.name.trim();
+
+    let targetGameId: string | null = null;
+    for (const [gameId, gamePassphrase] of this.passphrasesByGame.entries()) {
+      const game = this.games.get(gameId);
+      if (!game || game.status !== "waiting" || gamePassphrase !== passphrase) {
+        continue;
+      }
+      targetGameId = gameId;
+      break;
+    }
+
+    if (!targetGameId) {
+      const created = await this.createGame({
+        mainMinutes: DEFAULT_MATCH_MAIN_MINUTES,
+        byoSeconds: DEFAULT_MATCH_BYO_SECONDS,
+      });
+      targetGameId = created.gameId;
+      this.passphrasesByGame.set(targetGameId, passphrase);
+    }
+
+    const players = this.playersByGame.get(targetGameId);
+    const seat = pickAvailableSeat(players?.map((player) => player.seat) ?? []);
+    if (!seat) {
+      const created = await this.createGame({
+        mainMinutes: DEFAULT_MATCH_MAIN_MINUTES,
+        byoSeconds: DEFAULT_MATCH_BYO_SECONDS,
+      });
+      targetGameId = created.gameId;
+      this.passphrasesByGame.set(targetGameId, passphrase);
+    }
+
+    if (!targetGameId) {
+      throw new Error("GAME_NOT_FOUND");
+    }
+
+    const targetJoinToken = this.joinTokens.get(targetGameId);
+    if (!targetJoinToken) {
+      throw new Error("GAME_NOT_FOUND");
+    }
+
+    const reloadedPlayers = this.playersByGame.get(targetGameId) ?? [];
+    const resolvedSeat = pickAvailableSeat(reloadedPlayers.map((player) => player.seat));
+    if (!resolvedSeat) {
+      throw new Error("GAME_IS_FULL");
+    }
+
+    const joined = await this.joinGame(targetGameId, {
+      name: normalizedName,
+      seat: resolvedSeat,
+      joinToken: targetJoinToken,
+    });
+
+    return {
+      gameId: targetGameId,
+      guestId: joined.guestId,
+      sessionToken: joined.sessionToken,
+      managedToken: joined.managedToken,
+      seat: joined.seat,
     };
   }
 
@@ -558,6 +637,95 @@ export class PostgresStore implements GameStore {
     return mapGameRow(result.rows[0]);
   }
 
+  private async lockWaitingGameByPassphrase(client: Queryable, passphraseHash: string): Promise<PersistedGame | null> {
+    const result = await client.query<GameRow>(
+      `SELECT
+         id,
+         status,
+         turn,
+         state_json,
+         main_seconds_black,
+         main_seconds_white,
+         byo_seconds_black,
+         byo_seconds_white,
+         result_type,
+         winner,
+         version,
+         turn_started_at_ms,
+         created_at,
+         updated_at,
+         join_token_hash
+       FROM games
+       WHERE status = 'waiting' AND join_token_hash = $1
+       ORDER BY created_at ASC
+       LIMIT 1
+       FOR UPDATE`,
+      [passphraseHash],
+    );
+
+    if (!result.rowCount) {
+      return null;
+    }
+
+    return mapGameRow(result.rows[0]);
+  }
+
+  private async createMatchGame(client: Queryable, passphraseHash: string): Promise<PersistedGame> {
+    const gameId = randomUUID();
+    const nowMs = Date.now();
+    const nowIso = new Date(nowMs).toISOString();
+    const mainSeconds = DEFAULT_MATCH_MAIN_MINUTES * 60;
+
+    await client.query(
+      `INSERT INTO games (
+         id,
+         status,
+         turn,
+         state_json,
+         main_seconds_black,
+         main_seconds_white,
+         byo_seconds_black,
+         byo_seconds_white,
+         result_type,
+         winner,
+         version,
+         join_token_hash,
+         turn_started_at_ms,
+         created_at,
+         updated_at
+       ) VALUES (
+         $1, 'waiting', 'black', $2::jsonb, $3, $3, $4, $4, NULL, NULL, 1, $5, $6, $7, $7
+       )`,
+      [
+        gameId,
+        JSON.stringify(createInitialGameState()),
+        mainSeconds,
+        DEFAULT_MATCH_BYO_SECONDS,
+        passphraseHash,
+        nowMs,
+        nowIso,
+      ],
+    );
+
+    return {
+      id: gameId,
+      status: "waiting",
+      turn: "black",
+      state: createInitialGameState(),
+      mainSecondsBlack: mainSeconds,
+      mainSecondsWhite: mainSeconds,
+      byoSecondsBlack: DEFAULT_MATCH_BYO_SECONDS,
+      byoSecondsWhite: DEFAULT_MATCH_BYO_SECONDS,
+      resultType: null,
+      winner: null,
+      version: 1,
+      turnStartedAtMs: nowMs,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+      joinTokenHash: passphraseHash,
+    };
+  }
+
   private async updateGame(client: Queryable, game: PersistedGame, previousVersion: number): Promise<void> {
     const result = await client.query(
       `UPDATE games
@@ -704,6 +872,69 @@ export class PostgresStore implements GameStore {
         sessionToken,
         managedToken: issueManagedAuthToken(guestId),
         seat: input.seat,
+      };
+    });
+  }
+
+  async matchByPassphrase(input: LobbyMatchInput): Promise<LobbyMatchResult> {
+    const passphraseHash = hashToken(input.passphrase.trim());
+    const normalizedName = input.name.trim();
+
+    return this.withTransaction(async (client) => {
+      let game = await this.lockWaitingGameByPassphrase(client, passphraseHash);
+      if (!game) {
+        game = await this.createMatchGame(client, passphraseHash);
+      }
+
+      let playersResult = await client.query<{ seat: Seat }>(
+        `SELECT seat
+         FROM game_players
+         WHERE game_id = $1
+         FOR UPDATE`,
+        [game.id],
+      );
+
+      let seat = pickAvailableSeat(playersResult.rows.map((row) => row.seat));
+      if (!seat) {
+        game = await this.createMatchGame(client, passphraseHash);
+        playersResult = { rows: [], rowCount: 0 };
+        seat = "black";
+      }
+
+      const sessionToken = createSessionToken();
+      const guestId = randomUUID();
+      const joinedAt = toIsoNow();
+
+      await client.query(
+        `INSERT INTO game_players (
+           id,
+           game_id,
+           seat,
+           guest_id,
+           display_name,
+           session_token_hash,
+           joined_at
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [randomUUID(), game.id, seat, guestId, normalizedName, hashToken(sessionToken), joinedAt],
+      );
+
+      const nowMs = Date.now();
+      const nowIso = new Date(nowMs).toISOString();
+      game.status = playersResult.rows.length + 1 === 2 ? "active" : "waiting";
+      game.updatedAt = nowIso;
+      game.version += 1;
+      if (game.status === "active") {
+        game.turnStartedAtMs = nowMs;
+      }
+
+      await this.updateGame(client, game, game.version - 1);
+
+      return {
+        gameId: game.id,
+        guestId,
+        sessionToken,
+        managedToken: issueManagedAuthToken(guestId),
+        seat,
       };
     });
   }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -43,6 +43,19 @@ export type JoinGameInput = {
   joinToken: string;
 };
 
+export type LobbyMatchInput = {
+  passphrase: string;
+  name: string;
+};
+
+export type LobbyMatchResult = {
+  gameId: string;
+  guestId: string;
+  sessionToken: string;
+  managedToken: string | null;
+  seat: Seat;
+};
+
 export type MoveRecord = {
   ply: number;
   actorSeat: Seat;

--- a/server/src/validators.ts
+++ b/server/src/validators.ts
@@ -1,5 +1,5 @@
 import type { Move } from "../../core/src/types";
-import type { CreateGameInput, JoinGameInput } from "./types";
+import type { CreateGameInput, JoinGameInput, LobbyMatchInput } from "./types";
 
 export type MoveRequestBody = {
   move: Move;
@@ -16,8 +16,10 @@ const BYO_SECONDS_STEP = 10;
 const MIN_PLAYER_NAME_LENGTH = 2;
 const MAX_PLAYER_NAME_LENGTH = 20;
 const MIN_JOIN_TOKEN_LENGTH = 16;
+const MAX_PASSPHRASE_LENGTH = 8;
 const VALID_SEATS = new Set<JoinGameInput["seat"]>(["black", "white"]);
 const DROP_KINDS = new Set(["rook", "bishop", "gold", "silver", "knight", "lance", "pawn"]);
+const PASSPHRASE_PATTERN = /^[A-Za-z0-9]+$/;
 
 function isRecord(input: unknown): input is JsonRecord {
   return !!input && typeof input === "object";
@@ -78,9 +80,7 @@ export function isValidJoinGameInput(input: unknown): input is JoinGameInput {
     return false;
   }
 
-  const name = typeof input.name === "string" ? input.name : "";
-  const trimmed = name.trim();
-  if (!trimmed || trimmed.length < MIN_PLAYER_NAME_LENGTH || trimmed.length > MAX_PLAYER_NAME_LENGTH) {
+  if (!isValidPlayerName(input.name)) {
     return false;
   }
 
@@ -89,6 +89,32 @@ export function isValidJoinGameInput(input: unknown): input is JoinGameInput {
   }
 
   return typeof input.joinToken === "string" && input.joinToken.length >= MIN_JOIN_TOKEN_LENGTH;
+}
+
+function isValidPlayerName(name: unknown): boolean {
+  if (typeof name !== "string") {
+    return false;
+  }
+
+  const trimmed = name.trim();
+  return trimmed.length >= MIN_PLAYER_NAME_LENGTH && trimmed.length <= MAX_PLAYER_NAME_LENGTH;
+}
+
+export function isValidLobbyMatchInput(input: unknown): input is LobbyMatchInput {
+  if (!isRecord(input)) {
+    return false;
+  }
+
+  if (!isValidPlayerName(input.name)) {
+    return false;
+  }
+
+  if (typeof input.passphrase !== "string") {
+    return false;
+  }
+
+  const passphrase = input.passphrase.trim();
+  return passphrase.length > 0 && passphrase.length <= MAX_PASSPHRASE_LENGTH && PASSPHRASE_PATTERN.test(passphrase);
 }
 
 export function isMoveRequestBody(input: unknown): input is MoveRequestBody {

--- a/server/tests/onlineFlow.test.ts
+++ b/server/tests/onlineFlow.test.ts
@@ -28,6 +28,57 @@ afterAll(async () => {
 });
 
 describe("online match backend flow", () => {
+  test("matches two players with the same passphrase and starts game", async () => {
+    const firstRes = await fetch(`${baseUrl}/api/lobby/match`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ passphrase: "Room123", name: "first" }),
+    });
+    expect(firstRes.status).toBe(200);
+    const first = (await firstRes.json()) as { gameId: string; seat: string };
+    expect(first.seat).toBe("black");
+
+    const secondRes = await fetch(`${baseUrl}/api/lobby/match`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ passphrase: "Room123", name: "second" }),
+    });
+    expect(secondRes.status).toBe(200);
+    const second = (await secondRes.json()) as { gameId: string; seat: string };
+    expect(second.gameId).toBe(first.gameId);
+    expect(second.seat).toBe("white");
+
+    const snapshotRes = await fetch(`${baseUrl}/api/games/${first.gameId}`);
+    expect(snapshotRes.status).toBe(200);
+    const snapshot = (await snapshotRes.json()) as { status: string };
+    expect(snapshot.status).toBe("active");
+  });
+
+  test("creates a new waiting game when same passphrase game is already active", async () => {
+    const firstRes = await fetch(`${baseUrl}/api/lobby/match`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ passphrase: "Again77", name: "first" }),
+    });
+    const first = (await firstRes.json()) as { gameId: string };
+
+    await fetch(`${baseUrl}/api/lobby/match`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ passphrase: "Again77", name: "second" }),
+    });
+
+    const thirdRes = await fetch(`${baseUrl}/api/lobby/match`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ passphrase: "Again77", name: "third" }),
+    });
+    expect(thirdRes.status).toBe(200);
+    const third = (await thirdRes.json()) as { gameId: string; seat: string };
+    expect(third.gameId).not.toBe(first.gameId);
+    expect(third.seat).toBe("black");
+  });
+
   test("create -> join -> move -> resign", async () => {
     const createRes = await fetch(`${baseUrl}/api/games`, {
       method: "POST",

--- a/server/tests/postgresStore.test.ts
+++ b/server/tests/postgresStore.test.ts
@@ -11,6 +11,20 @@ afterAll(async () => {
 });
 
 describe("PostgresStore", () => {
+  test("matches by passphrase and creates a new game after room is full", async () => {
+    const store = new PostgresStore(pool);
+
+    const first = await store.matchByPassphrase({ passphrase: "Room123", name: "first" });
+    const second = await store.matchByPassphrase({ passphrase: "Room123", name: "second" });
+    expect(second.gameId).toBe(first.gameId);
+    expect(first.seat).toBe("black");
+    expect(second.seat).toBe("white");
+
+    const third = await store.matchByPassphrase({ passphrase: "Room123", name: "third" });
+    expect(third.gameId).not.toBe(first.gameId);
+    expect(third.seat).toBe("black");
+  });
+
   test("persists game state and move records across store re-instantiation", async () => {
     const store1 = new PostgresStore(pool);
     const created = await store1.createGame({ mainMinutes: 5, byoSeconds: 30 });

--- a/server/tests/validationErrors.test.ts
+++ b/server/tests/validationErrors.test.ts
@@ -28,6 +28,18 @@ afterAll(async () => {
 });
 
 describe("request validation errors", () => {
+  test("returns 400 when lobby match payload is invalid", async () => {
+    const response = await fetch(`${baseUrl}/api/lobby/match`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ passphrase: "too-long-9", name: "player" }),
+    });
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBe("INVALID_MATCH_PAYLOAD");
+  });
+
   test("returns 400 when JSON body is malformed", async () => {
     const response = await fetch(`${baseUrl}/api/games`, {
       method: "POST",

--- a/server/tests/validators.test.ts
+++ b/server/tests/validators.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { isMoveRequestBody, isValidCreateGameInput, isValidJoinGameInput } from "../src/validators";
+import { isMoveRequestBody, isValidCreateGameInput, isValidJoinGameInput, isValidLobbyMatchInput } from "../src/validators";
 
 describe("validators", () => {
   describe("isValidCreateGameInput", () => {
@@ -96,6 +96,26 @@ describe("validators", () => {
           move: { drop: "king", to: { x: 4, y: 4 } },
         }),
       ).toBe(false);
+    });
+  });
+
+  describe("isValidLobbyMatchInput", () => {
+    test("accepts valid passphrase and name", () => {
+      expect(
+        isValidLobbyMatchInput({
+          passphrase: "Room123",
+          name: "player",
+        }),
+      ).toBe(true);
+    });
+
+    test("rejects invalid passphrase and name", () => {
+      expect(isValidLobbyMatchInput({ passphrase: "", name: "player" })).toBe(false);
+      expect(isValidLobbyMatchInput({ passphrase: "abcdefghi", name: "player" })).toBe(false);
+      expect(isValidLobbyMatchInput({ passphrase: "abc-123", name: "player" })).toBe(false);
+      expect(isValidLobbyMatchInput({ passphrase: "abc123", name: "a" })).toBe(false);
+      expect(isValidLobbyMatchInput({ passphrase: "abc123", name: " ".repeat(3) })).toBe(false);
+      expect(isValidLobbyMatchInput({ passphrase: "abc123", name: "a".repeat(21) })).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## 概要
- ロビー参加を合言葉マッチング方式へ統一しました。
- 合言葉は半角英数字1〜8文字で検証します。

## 変更点
- POST /api/lobby/match を追加
- クライアントの参加導線を matchLobby に変更
- セットアップ画面を合言葉入力UIへ変更
- InMemoryStore / PostgresStore にマッチング処理を追加
- 関連テストを追加・更新

## 確認
- npm test
- npm run build
- 変更対象ファイルで文字化けなし