### PR TITLE
Issue #73 対局UI: 狭幅時でも盤と駒台の位置を固定

### DIFF
--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -498,29 +498,6 @@ body {
     grid-template-columns: 1fr;
   }
 
-  .game-area {
-    display: grid;
-    gap: 10px;
-  }
-
-  .hand-anchor {
-    position: static;
-    width: 240px;
-    margin: 0 auto;
-  }
-
-  .hand-anchor-white {
-    order: 1;
-  }
-
-  .board {
-    order: 2;
-  }
-
-  .hand-anchor-black {
-    order: 3;
-  }
-
   .hand-pieces {
     grid-template-columns: repeat(4, 1fr);
   }

--- a/app/tests/layoutCss.test.ts
+++ b/app/tests/layoutCss.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+function readGlobalCss(): string {
+  return readFileSync(join(process.cwd(), "app/src/styles/globals.css"), "utf8");
+}
+
+describe("game layout css", () => {
+  test("keeps board and hand anchors fixed even on narrow screens", () => {
+    const css = readGlobalCss().replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+    expect(css).toMatch(/\.hand-anchor\s*\{[\s\S]*?position:\s*absolute;/);
+
+    const narrowMediaStart = css.indexOf("@media (max-width: 980px) {");
+    expect(narrowMediaStart).toBeGreaterThanOrEqual(0);
+    const nextMediaStart = css.indexOf("@media (min-width: 860px)", narrowMediaStart);
+    const block = css.slice(
+      narrowMediaStart,
+      nextMediaStart === -1 ? undefined : nextMediaStart,
+    );
+
+    expect(block).not.toMatch(/\.game-area\s*\{/);
+    expect(block).not.toMatch(/\.hand-anchor\s*\{/);
+    expect(block).not.toMatch(/order:\s*\d/);
+    expect(block).not.toMatch(/position:\s*static/);
+  });
+});


### PR DESCRIPTION
## 概要
- 狭幅時の自動再配置をやめ、盤と駒台の相対位置を固定しました
- 狭幅での見切れは許容し、重なりや上下入れ替えを防止します
- レイアウト退行を防ぐCSSテストを追加しました

## 変更内容
- app/src/styles/globals.css
- app/tests/layoutCss.test.ts

## テスト
- npm test -- app/tests/layoutCss.test.ts
- npm test
- npm run build

Closes #73