### PR TITLE
Issue #74 UI表記: 先手/後手へ統一しBlack/White表記を廃止

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1103,8 +1103,8 @@ export function App() {
       {session ? (
         <p className="session-summary">
           {matchMode === "online"
-            ? `gameId: ${session.gameId} / seat: ${session.seat} / name: ${session.displayName} / version: ${gameVersion}`
-            : `mode: bot / seat: ${session.seat} / name: ${session.displayName} / version: ${gameVersion}`}
+            ? `gameId: ${session.gameId} / 先後: ${winnerLabel(session.seat)} / name: ${session.displayName} / version: ${gameVersion}`
+            : `mode: bot / 先後: ${winnerLabel(session.seat)} / name: ${session.displayName} / version: ${gameVersion}`}
         </p>
       ) : matchMode === "online" && spectatorGameId ? (
         <p className="session-summary">mode: spectator / gameId: {spectatorGameId} / version: {gameVersion}</p>

--- a/app/src/ui/SetupScreen.tsx
+++ b/app/src/ui/SetupScreen.tsx
@@ -184,14 +184,14 @@ export function SetupScreen({
                     className={`setup-button ${joinSeat === "black" ? "is-selected" : ""}`.trim()}
                     onClick={() => onJoinSeatChange("black")}
                   >
-                    black
+                    先手
                   </button>
                   <button
                     type="button"
                     className={`setup-button ${joinSeat === "white" ? "is-selected" : ""}`.trim()}
                     onClick={() => onJoinSeatChange("white")}
                   >
-                    white
+                    後手
                   </button>
                 </div>
               </div>
@@ -262,14 +262,14 @@ export function SetupScreen({
                   className={`setup-button ${botSeat === "black" ? "is-selected" : ""}`.trim()}
                   onClick={() => onBotSeatChange("black")}
                 >
-                  black
+                  先手
                 </button>
                 <button
                   type="button"
                   className={`setup-button ${botSeat === "white" ? "is-selected" : ""}`.trim()}
                   onClick={() => onBotSeatChange("white")}
                 >
-                  white
+                  後手
                 </button>
               </div>
             </div>

--- a/app/tests/seatNotationUi.test.ts
+++ b/app/tests/seatNotationUi.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(process.cwd(), relativePath), "utf8")
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n/g, "\n");
+}
+
+describe("UI seat notation", () => {
+  test("uses 先手/後手 labels instead of Black/White in setup and game summaries", () => {
+    const setupScreen = readSource("app/src/ui/SetupScreen.tsx");
+    expect(setupScreen).toContain("先手");
+    expect(setupScreen).toContain("後手");
+    expect(setupScreen).not.toMatch(/>\s*black\s*</);
+    expect(setupScreen).not.toMatch(/>\s*white\s*</);
+
+    const app = readSource("app/src/App.tsx");
+    expect(app).toContain("winnerLabel(session.seat)");
+    expect(app).not.toContain("seat: ${session.seat}");
+  });
+});


### PR DESCRIPTION
## 概要
- ユーザー向けの席表記を Black/White ではなく 先手/後手 に統一しました
- ロビーの席選択ボタンとゲーム画面のセッション概要表示を日本語化しました
- UI文言で Black/White が再発しないよう退行テストを追加しました

## 変更ファイル
- app/src/ui/SetupScreen.tsx
- app/src/App.tsx
- app/tests/seatNotationUi.test.ts

## テスト
- npm test -- app/tests/seatNotationUi.test.ts
- npm test
- npm run build

Closes #74