### PR TITLE
fix: issue #77 着手時の盤面揺れを防止

### DIFF
--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -255,8 +255,8 @@ body {
 .history-list {
   margin: 0;
   padding-left: 32px;
-  max-height: 220px;
-  overflow: auto;
+  height: 220px;
+  overflow-y: auto;
 }
 
 .history-list li::marker {

--- a/app/tests/boardStabilityCss.test.ts
+++ b/app/tests/boardStabilityCss.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+function readGlobalCss(): string {
+  return readFileSync(join(process.cwd(), "app/src/styles/globals.css"), "utf8");
+}
+
+describe("board stability css", () => {
+  test("keeps move history viewport height fixed to avoid move-time layout shifts", () => {
+    const css = readGlobalCss().replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+    const match = css.match(/\.history-list\s*\{([\s\S]*?)\}/);
+    expect(match).not.toBeNull();
+    const block = match?.[1] ?? "";
+
+    expect(block).toMatch(/height:\s*220px;/);
+    expect(block).toMatch(/overflow(?:-y)?:\s*auto;/);
+    expect(block).not.toMatch(/max-height:/);
+  });
+});


### PR DESCRIPTION
## 概要
- 棋譜リスト領域の高さを固定し、着手ごとの高さ変動を解消
- 盤面周辺レイアウトのシフトを防ぐため、履歴領域を内部スクロール化
- レイアウト安定性を担保するCSSテストを追加

## 検証
- npm run test
- npm run build

Closes #77