### PR TITLE
fix: #71 白番視点の盤面表示に対応

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1134,6 +1134,10 @@ export function App() {
     return projectClockState(clockState, state.turn, clockTurnStartedAtMs, clockNowMs);
   }, [screenMode, matchMode, gameOver, clockState, state.turn, clockTurnStartedAtMs, clockNowMs]);
 
+  const boardPerspective: Color = playerSeat === "white" ? "white" : "black";
+  const topSideColor: Color = boardPerspective === "white" ? "black" : "white";
+  const bottomSideColor: Color = oppositeColor(topSideColor);
+
   return (
     <main className="app">
       <h1>Shogi Game</h1>
@@ -1191,14 +1195,14 @@ export function App() {
         <div className="hand-anchor hand-anchor-white">
           <Hand
             hands={state.hands}
-            color="white"
-            active={canOperateNow && playerSeat === "white"}
+            color={topSideColor}
+            active={canOperateNow && playerSeat === topSideColor}
             selectedDrop={selectedDrop}
             onSelectDrop={toggleDropSelection}
           />
           <div className="clock-panel">
             <p className="clock-title">持ち時間</p>
-            <p className="clock-main">{formatClockText(displayClockState.main.white, displayClockState.byo.white)}</p>
+            <p className="clock-main">{formatClockText(displayClockState.main[topSideColor], displayClockState.byo[topSideColor])}</p>
           </div>
           <section className="history-panel" aria-label="move history">
             <h2>棋譜</h2>
@@ -1216,18 +1220,19 @@ export function App() {
           legalTargetKeys={legalTargetKeys}
           checkedKing={checkedKing}
           interactive={canOperateNow}
+          perspective={boardPerspective}
           onSquareClick={onSquareClick}
         />
 
         <div className="hand-anchor hand-anchor-black">
           <div className="clock-panel">
             <p className="clock-title">持ち時間</p>
-            <p className="clock-main">{formatClockText(displayClockState.main.black, displayClockState.byo.black)}</p>
+            <p className="clock-main">{formatClockText(displayClockState.main[bottomSideColor], displayClockState.byo[bottomSideColor])}</p>
           </div>
           <Hand
             hands={state.hands}
-            color="black"
-            active={canOperateNow && playerSeat === "black"}
+            color={bottomSideColor}
+            active={canOperateNow && playerSeat === bottomSideColor}
             selectedDrop={selectedDrop}
             onSelectDrop={toggleDropSelection}
           />

--- a/app/src/game/position.ts
+++ b/app/src/game/position.ts
@@ -1,4 +1,9 @@
-import type { Position } from "../../../core/src/types";
+import { BOARD_SIZE } from "../../../core/src/constants";
+import type { Color, Position } from "../../../core/src/types";
+
+function getMirroredCoordinate(value: number): number {
+  return BOARD_SIZE - 1 - value;
+}
 
 export function positionToKey(position: Position): string {
   return `${position.x}:${position.y}`;
@@ -6,4 +11,19 @@ export function positionToKey(position: Position): string {
 
 export function isSamePosition(a: Position, b: Position): boolean {
   return a.x === b.x && a.y === b.y;
+}
+
+export function toBoardPosition(displayPosition: Position, perspective: Color): Position {
+  if (perspective === "black") {
+    return displayPosition;
+  }
+
+  return {
+    x: getMirroredCoordinate(displayPosition.x),
+    y: getMirroredCoordinate(displayPosition.y),
+  };
+}
+
+export function toDisplayPosition(boardPosition: Position, perspective: Color): Position {
+  return toBoardPosition(boardPosition, perspective);
 }

--- a/app/src/ui/Board.tsx
+++ b/app/src/ui/Board.tsx
@@ -1,5 +1,6 @@
-﻿import { type BoardState, type Position } from "../../../core/src/types";
-import { positionToKey } from "../game/position";
+﻿import { BOARD_SIZE } from "../../../core/src/constants";
+import { type BoardState, type Color, type Position } from "../../../core/src/types";
+import { positionToKey, toBoardPosition } from "../game/position";
 import { Piece } from "./Piece";
 
 type BoardProps = {
@@ -8,22 +9,26 @@ type BoardProps = {
   legalTargetKeys: ReadonlySet<string>;
   checkedKing: Position | null;
   interactive: boolean;
+  perspective: Color;
   onSquareClick: (position: Position) => void;
 };
 
-export function Board({ board, selected, legalTargetKeys, checkedKing, interactive, onSquareClick }: BoardProps) {
+export function Board({ board, selected, legalTargetKeys, checkedKing, interactive, perspective, onSquareClick }: BoardProps) {
+  const displayIndices = Array.from({ length: BOARD_SIZE }, (_, index) => index);
+
   return (
     <section className={`board ${interactive ? "" : "is-readonly"}`.trim()} aria-label="Shogi board">
-      {board.map((row, y) =>
-        row.map((cell, x) => {
-          const square = { x, y };
-          const isSelected = selected?.x === x && selected?.y === y;
+      {displayIndices.map((displayY) =>
+        displayIndices.map((displayX) => {
+          const square = toBoardPosition({ x: displayX, y: displayY }, perspective);
+          const cell = board[square.y][square.x];
+          const isSelected = selected?.x === square.x && selected?.y === square.y;
           const isLegalTarget = legalTargetKeys.has(positionToKey(square));
-          const isCheckedKing = checkedKing?.x === x && checkedKing?.y === y;
+          const isCheckedKing = checkedKing?.x === square.x && checkedKing?.y === square.y;
 
           return (
             <button
-              key={`${x}-${y}`}
+              key={`${displayX}-${displayY}`}
               className={`square ${isSelected ? "is-selected" : ""} ${isLegalTarget ? "is-legal-target" : ""} ${isCheckedKing ? "is-checked-king" : ""}`.trim()}
               disabled={!interactive}
               onClick={() => onSquareClick(square)}

--- a/app/tests/position.test.ts
+++ b/app/tests/position.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { isSamePosition, positionToKey } from "../src/game/position";
+import { isSamePosition, positionToKey, toBoardPosition, toDisplayPosition } from "../src/game/position";
 
 describe("position helpers", () => {
   test("positionToKey creates stable coordinate key", () => {
@@ -11,5 +11,16 @@ describe("position helpers", () => {
     expect(isSamePosition({ x: 1, y: 2 }, { x: 1, y: 2 })).toBe(true);
     expect(isSamePosition({ x: 1, y: 2 }, { x: 2, y: 2 })).toBe(false);
     expect(isSamePosition({ x: 1, y: 2 }, { x: 1, y: 3 })).toBe(false);
+  });
+
+  test("keeps coordinates as-is for black perspective", () => {
+    const position = { x: 2, y: 6 };
+    expect(toBoardPosition(position, "black")).toEqual(position);
+    expect(toDisplayPosition(position, "black")).toEqual(position);
+  });
+
+  test("mirrors coordinates for white perspective", () => {
+    expect(toBoardPosition({ x: 0, y: 0 }, "white")).toEqual({ x: 8, y: 8 });
+    expect(toDisplayPosition({ x: 8, y: 8 }, "white")).toEqual({ x: 0, y: 0 });
   });
 });


### PR DESCRIPTION
## 概要
- 視点切り替え用に盤座標と表示座標を変換するヘルパーを追加
- 表示座標でマスを描画し、内部の盤座標へ正しくマッピング
- プレイヤー視点に合わせて上下の持ち駒・時計表示の参照先を切り替え
- 先手/後手視点の座標変換テストを追加

## テスト
- npm.cmd run test -- app/tests/position.test.ts

Closes #71