### PR TITLE
feat: #75 先後をランダムに割り当てるロビーマッチング

### DIFF
--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -150,6 +150,17 @@ function pickAvailableSeat(seats: readonly Seat[]): Seat | null {
   return null;
 }
 
+function pickRandomSeat(): Seat {
+  return Math.random() < 0.5 ? "black" : "white";
+}
+
+function pickLobbySeat(seats: readonly Seat[]): Seat | null {
+  if (seats.length === 0) {
+    return pickRandomSeat();
+  }
+  return pickAvailableSeat(seats);
+}
+
 function oppositeSeat(seat: Seat): Seat {
   return seat === "black" ? "white" : "black";
 }
@@ -572,7 +583,7 @@ export class InMemoryStore implements GameStore {
     }
 
     const players = this.playersByGame.get(targetGameId);
-    const seat = pickAvailableSeat(players?.map((player) => player.seat) ?? []);
+    const seat = pickLobbySeat(players?.map((player) => player.seat) ?? []);
     if (!seat) {
       const created = await this.createGame({
         mainMinutes: DEFAULT_MATCH_MAIN_MINUTES,
@@ -592,7 +603,7 @@ export class InMemoryStore implements GameStore {
     }
 
     const reloadedPlayers = this.playersByGame.get(targetGameId) ?? [];
-    const resolvedSeat = pickAvailableSeat(reloadedPlayers.map((player) => player.seat));
+    const resolvedSeat = pickLobbySeat(reloadedPlayers.map((player) => player.seat));
     if (!resolvedSeat) {
       throw new Error("GAME_IS_FULL");
     }
@@ -1042,11 +1053,14 @@ export class PostgresStore implements GameStore {
         [game.id],
       );
 
-      let seat = pickAvailableSeat(playersResult.rows.map((row) => row.seat));
+      let seat = pickLobbySeat(playersResult.rows.map((row) => row.seat));
       if (!seat) {
         game = await this.createMatchGame(client, passphraseHash);
         playersResult = { rows: [], rowCount: 0 };
-        seat = "black";
+        seat = pickLobbySeat([]);
+      }
+      if (!seat) {
+        throw new Error("GAME_IS_FULL");
       }
 
       const sessionToken = createSessionToken();

--- a/server/tests/onlineFlow.test.ts
+++ b/server/tests/onlineFlow.test.ts
@@ -35,8 +35,8 @@ describe("online match backend flow", () => {
       body: JSON.stringify({ passphrase: "Room123", name: "first" }),
     });
     expect(firstRes.status).toBe(200);
-    const first = (await firstRes.json()) as { gameId: string; seat: string };
-    expect(first.seat).toBe("black");
+    const first = (await firstRes.json()) as { gameId: string; seat: string; sessionToken: string };
+    expect(["black", "white"]).toContain(first.seat);
 
     const secondRes = await fetch(`${baseUrl}/api/lobby/match`, {
       method: "POST",
@@ -44,9 +44,24 @@ describe("online match backend flow", () => {
       body: JSON.stringify({ passphrase: "Room123", name: "second" }),
     });
     expect(secondRes.status).toBe(200);
-    const second = (await secondRes.json()) as { gameId: string; seat: string };
+    const second = (await secondRes.json()) as { gameId: string; seat: string; sessionToken: string };
     expect(second.gameId).toBe(first.gameId);
-    expect(second.seat).toBe("white");
+    expect(["black", "white"]).toContain(second.seat);
+    expect(second.seat).not.toBe(first.seat);
+
+    const firstMeRes = await fetch(`${baseUrl}/api/games/${first.gameId}/me`, {
+      headers: { authorization: `Bearer ${first.sessionToken}` },
+    });
+    expect(firstMeRes.status).toBe(200);
+    const firstMe = (await firstMeRes.json()) as { seat: string };
+    expect(firstMe.seat).toBe(first.seat);
+
+    const secondMeRes = await fetch(`${baseUrl}/api/games/${second.gameId}/me`, {
+      headers: { authorization: `Bearer ${second.sessionToken}` },
+    });
+    expect(secondMeRes.status).toBe(200);
+    const secondMe = (await secondMeRes.json()) as { seat: string };
+    expect(secondMe.seat).toBe(second.seat);
 
     const snapshotRes = await fetch(`${baseUrl}/api/games/${first.gameId}`);
     expect(snapshotRes.status).toBe(200);
@@ -76,7 +91,7 @@ describe("online match backend flow", () => {
     expect(thirdRes.status).toBe(200);
     const third = (await thirdRes.json()) as { gameId: string; seat: string };
     expect(third.gameId).not.toBe(first.gameId);
-    expect(third.seat).toBe("black");
+    expect(["black", "white"]).toContain(third.seat);
   });
 
   test("create -> join -> move -> resign", async () => {

--- a/server/tests/postgresStore.test.ts
+++ b/server/tests/postgresStore.test.ts
@@ -17,12 +17,28 @@ describe("PostgresStore", () => {
     const first = await store.matchByPassphrase({ passphrase: "Room123", name: "first" });
     const second = await store.matchByPassphrase({ passphrase: "Room123", name: "second" });
     expect(second.gameId).toBe(first.gameId);
-    expect(first.seat).toBe("black");
-    expect(second.seat).toBe("white");
+    expect(["black", "white"]).toContain(first.seat);
+    expect(["black", "white"]).toContain(second.seat);
+    expect(second.seat).not.toBe(first.seat);
 
     const third = await store.matchByPassphrase({ passphrase: "Room123", name: "third" });
     expect(third.gameId).not.toBe(first.gameId);
-    expect(third.seat).toBe("black");
+    expect(["black", "white"]).toContain(third.seat);
+  });
+
+  test("uses random seat for first lobby player and assigns opposite to second player", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.9);
+    try {
+      const store = new PostgresStore(pool);
+
+      const first = await store.matchByPassphrase({ passphrase: "RandSeat", name: "first" });
+      const second = await store.matchByPassphrase({ passphrase: "RandSeat", name: "second" });
+
+      expect(first.seat).toBe("white");
+      expect(second.seat).toBe("black");
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 
   test("persists game state and move records across store re-instantiation", async () => {


### PR DESCRIPTION
## 概要
- 合言葉マッチングで1人目の先後割り当てをランダム化
- 2人目は残りの先後に自動割り当てし、黒白ペアを保証
- InMemoryStore と PostgresStore の両実装に同一ロジックを適用
- 固定先後前提を外した統合テスト・ストアテストに更新

## テスト
- npm.cmd run test -- server/tests/onlineFlow.test.ts server/tests/postgresStore.test.ts
- npm.cmd run test -- server/tests
- npm.cmd run test

Closes #75