### PR TITLE
feat: #78 Bot戦の時計表示を無効化

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1196,10 +1196,12 @@ export function App() {
             selectedDrop={selectedDrop}
             onSelectDrop={toggleDropSelection}
           />
-          <div className="clock-panel">
-            <p className="clock-title">持ち時間</p>
-            <p className="clock-main">{formatClockText(displayClockState.main.white, displayClockState.byo.white)}</p>
-          </div>
+          {matchMode === "online" ? (
+            <div className="clock-panel">
+              <p className="clock-title">持ち時間</p>
+              <p className="clock-main">{formatClockText(displayClockState.main.white, displayClockState.byo.white)}</p>
+            </div>
+          ) : null}
           <section className="history-panel" aria-label="move history">
             <h2>棋譜</h2>
             <ol className="history-list">
@@ -1220,10 +1222,12 @@ export function App() {
         />
 
         <div className="hand-anchor hand-anchor-black">
-          <div className="clock-panel">
-            <p className="clock-title">持ち時間</p>
-            <p className="clock-main">{formatClockText(displayClockState.main.black, displayClockState.byo.black)}</p>
-          </div>
+          {matchMode === "online" ? (
+            <div className="clock-panel">
+              <p className="clock-title">持ち時間</p>
+              <p className="clock-main">{formatClockText(displayClockState.main.black, displayClockState.byo.black)}</p>
+            </div>
+          ) : null}
           <Hand
             hands={state.hands}
             color="black"

--- a/app/tests/botClockUi.test.ts
+++ b/app/tests/botClockUi.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(process.cwd(), relativePath), "utf8")
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n/g, "\n");
+}
+
+describe("bot clock UI", () => {
+  test("renders both clock panels only in online mode", () => {
+    const app = readSource("app/src/App.tsx");
+    const allClockPanels = app.match(/<div className=\"clock-panel\">/g) ?? [];
+    const conditionalClockPanels = app.match(/matchMode === \"online\"\s*\?\s*\(\s*<div className=\"clock-panel\">/g) ?? [];
+
+    expect(allClockPanels).toHaveLength(2);
+    expect(conditionalClockPanels).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## 概要
- Bot対局時は2つの時計パネルを非表示化
- オンライン対局の時計表示は従来どおり維持
- 時計パネルがオンライン時のみ描画される回帰テストを追加

## テスト
- npm.cmd run test -- app/tests/botClockUi.test.ts app/tests/botMode.test.ts app/tests/timeControl.test.ts
- npm.cmd run test

Closes #78