### PR TITLE
feat: #79 アプリタイトルを将棋倶楽部2.4へ変更

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Shogi Game</title>
+    <title>将棋倶楽部2.4</title>
   </head>
   <body>
     <div id="root"></div>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1136,7 +1136,7 @@ export function App() {
 
   return (
     <main className="app">
-      <h1>Shogi Game</h1>
+      <h1>将棋倶楽部2.4</h1>
       {session ? (
         <p className="session-summary">
           {matchMode === "online"

--- a/app/src/ui/SetupScreen.tsx
+++ b/app/src/ui/SetupScreen.tsx
@@ -57,7 +57,7 @@ export function SetupScreen({
 }: SetupScreenProps) {
   return (
     <main className="app">
-      <h1>Shogi Game</h1>
+      <h1>将棋倶楽部2.4</h1>
       <section className="start-screen" aria-label="match setup">
         <h2>{setupMode === "online" ? "オンライン対局" : "Bot対局"}</h2>
         <div className="setup-options" aria-label="match mode toggle">

--- a/app/tests/appTitleUi.test.ts
+++ b/app/tests/appTitleUi.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(process.cwd(), relativePath), "utf8")
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n/g, "\n");
+}
+
+describe("application title", () => {
+  test("uses 将棋倶楽部2.4 in UI headings and html title", () => {
+    const app = readSource("app/src/App.tsx");
+    const setupScreen = readSource("app/src/ui/SetupScreen.tsx");
+    const indexHtml = readSource("app/index.html");
+
+    expect(app).toContain("<h1>将棋倶楽部2.4</h1>");
+    expect(setupScreen).toContain("<h1>将棋倶楽部2.4</h1>");
+    expect(indexHtml).toContain("<title>将棋倶楽部2.4</title>");
+
+    expect(app).not.toContain("<h1>Shogi Game</h1>");
+    expect(setupScreen).not.toContain("<h1>Shogi Game</h1>");
+    expect(indexHtml).not.toContain("<title>Shogi Game</title>");
+  });
+});


### PR DESCRIPTION
## 概要
- セットアップ画面と対局画面のアプリタイトルを「将棋倶楽部2.4」に変更
- ブラウザタブタイトル（app/index.html）も「将棋倶楽部2.4」に統一
- タイトル表記の回帰テストを追加

## テスト
- npm.cmd run test -- app/tests/appTitleUi.test.ts app/tests/seatNotationUi.test.ts
- npm.cmd run test

Closes #79