### PR TITLE
feat: #80 対局画面のゲーム情報サマリーを非表示化

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1137,15 +1137,6 @@ export function App() {
   return (
     <main className="app">
       <h1>Shogi Game</h1>
-      {session ? (
-        <p className="session-summary">
-          {matchMode === "online"
-            ? `gameId: ${session.gameId} / 先後: ${winnerLabel(session.seat)} / name: ${session.displayName} / version: ${gameVersion}`
-            : `mode: bot / 先後: ${winnerLabel(session.seat)} / name: ${session.displayName} / version: ${gameVersion}`}
-        </p>
-      ) : matchMode === "online" && spectatorGameId ? (
-        <p className="session-summary">mode: spectator / gameId: {spectatorGameId} / version: {gameVersion}</p>
-      ) : null}
       {matchMode === "online" && networkBannerMessage ? (
         <section className={`network-banner ${isOffline ? "is-offline" : ""}`.trim()} role="status" aria-live="polite">
           <span>{networkBannerMessage}</span>

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -122,14 +122,6 @@ body {
   word-break: break-word;
 }
 
-.session-summary {
-  margin: 6px 0 12px;
-  padding: 8px 10px;
-  border: 1px solid #6e5838;
-  background: #fff3d8;
-  font-size: 13px;
-}
-
 .network-banner {
   margin: 0 auto 10px;
   width: min(620px, 100%);

--- a/app/tests/gameSummaryUi.test.ts
+++ b/app/tests/gameSummaryUi.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(process.cwd(), relativePath), "utf8")
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n/g, "\n");
+}
+
+describe("game summary UI", () => {
+  test("does not render the title-under summary row", () => {
+    const app = readSource("app/src/App.tsx");
+    expect(app).not.toContain('className="session-summary"');
+    expect(app).not.toContain("mode: spectator / gameId:");
+    expect(app).not.toContain("/ version: ${gameVersion}");
+  });
+});

--- a/app/tests/seatNotationUi.test.ts
+++ b/app/tests/seatNotationUi.test.ts
@@ -9,7 +9,7 @@ function readSource(relativePath: string): string {
 }
 
 describe("UI seat notation", () => {
-  test("uses 先手/後手 labels instead of Black/White in setup and game summaries", () => {
+  test("uses 先手/後手 labels instead of Black/White in setup UI", () => {
     const setupScreen = readSource("app/src/ui/SetupScreen.tsx");
     expect(setupScreen).toContain("先手");
     expect(setupScreen).toContain("後手");
@@ -17,7 +17,6 @@ describe("UI seat notation", () => {
     expect(setupScreen).not.toMatch(/>\s*white\s*</);
 
     const app = readSource("app/src/App.tsx");
-    expect(app).toContain("winnerLabel(session.seat)");
     expect(app).not.toContain("seat: ${session.seat}");
   });
 });


### PR DESCRIPTION
## 概要
- 対局画面のタイトル直下にあるゲーム情報サマリー行を削除
- 不要になった `.session-summary` CSS を削除
- サマリー非表示を確認する回帰テストを追加し、既存UIテストを調整

## テスト
- npm.cmd run test -- app/tests/gameSummaryUi.test.ts app/tests/seatNotationUi.test.ts
- npm.cmd run test

Closes #80