### PR TITLE
refactor: 合法手生成と時計処理を整理

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { applyMove } from "../../core/src/applyMove";
 import { findKingPosition, isInCheck } from "../../core/src/check";
-import { isCheckmate } from "../../core/src/checkmate";
 import { createInitialGameState } from "../../core/src/initialPosition";
-import { generateLegalMoves } from "../../core/src/moveGenerator";
+import { generateLegalTargets, hasAnyLegalMove } from "../../core/src/moveGenerator";
 import { canChoosePromotion, shouldAutoPromote } from "../../core/src/promotion";
 import { type BoardMove, type Color, type GameState, type Move, type PieceKind, type Position } from "../../core/src/types";
 import { PIECE_SOUND_PATH } from "./assets";
@@ -135,6 +134,25 @@ export function App() {
     setSelectedDrop(null);
     setPendingPromotion(null);
   }, []);
+
+  const resetLocalGameState = useCallback(() => {
+    const nowMs = Date.now();
+    setState(initialState);
+    setClockState(createClockState(initialTimeControl));
+    setClockTurnStartedAtMs(nowMs);
+    setClockNowMs(nowMs);
+    setGameVersion(1);
+    latestVersionRef.current = 1;
+    setWinner(null);
+    setResultText(null);
+    setGameOver(false);
+    setShowRestartDialog(false);
+    setIsPaused(false);
+    setMoveHistory([]);
+    setGameMessage(null);
+    setNetworkBannerMessage(null);
+    clearSelections();
+  }, [clearSelections, initialState, initialTimeControl]);
 
   const onSetupModeChange = useCallback((mode: MatchMode) => {
     setSetupMode(mode);
@@ -422,21 +440,7 @@ export function App() {
       setMatchMode("online");
       setSetupMode("online");
       setScreenMode("game");
-      setIsPaused(false);
-      setMoveHistory([]);
-      setWinner(null);
-      setResultText(null);
-      setGameOver(false);
-      setShowRestartDialog(false);
-      setGameMessage(null);
-      setNetworkBannerMessage(null);
-      setState(initialState);
-      setClockState(createClockState(initialTimeControl));
-      setClockTurnStartedAtMs(Date.now());
-      setClockNowMs(Date.now());
-      setGameVersion(1);
-      latestVersionRef.current = 1;
-      clearSelections();
+      resetLocalGameState();
 
       const synced = await syncSnapshot(gameId, { showDialog: false });
       if (!synced) {
@@ -455,7 +459,7 @@ export function App() {
     } finally {
       setIsStartingSpectate(false);
     }
-  }, [clearSelections, initialState, initialTimeControl, replaceSpectateLocation, syncSnapshot]);
+  }, [replaceSpectateLocation, resetLocalGameState, syncSnapshot]);
 
   const onStartSpectate = useCallback(async () => {
     const validated = validateSpectateGameForm({ gameId: spectateGameId });
@@ -492,29 +496,15 @@ export function App() {
       setSpectatorGameId(null);
       setMatchMode("bot");
       setScreenMode("game");
-      setState(initialState);
-      setClockState(createClockState(initialTimeControl));
-      setClockTurnStartedAtMs(Date.now());
-      setClockNowMs(Date.now());
-      setGameVersion(1);
-      latestVersionRef.current = 1;
-      setWinner(null);
-      setResultText(null);
-      setGameOver(false);
-      setShowRestartDialog(false);
-      setIsPaused(false);
-      setMoveHistory([]);
-      setGameMessage(null);
-      setNetworkBannerMessage(null);
+      resetLocalGameState();
       setBotMessage(null);
       setSpectateMessage(null);
       setSpectateErrors([]);
       replaceSpectateLocation(null);
-      clearSelections();
     } finally {
       setIsStartingBot(false);
     }
-  }, [botName, botSeat, clearSelections, initialState, initialTimeControl, replaceSpectateLocation]);
+  }, [botName, botSeat, replaceSpectateLocation, resetLocalGameState]);
 
   useEffect(() => {
     if (!initialSpectateGameId || hasAutoStartedSpectateRef.current) {
@@ -707,30 +697,7 @@ export function App() {
       return [];
     }
 
-    const piece = state.board[selected.y][selected.x];
-    if (!piece || piece.color !== state.turn) {
-      return [];
-    }
-
-    const targets: Position[] = [];
-
-    for (let y = 0; y < 9; y += 1) {
-      for (let x = 0; x < 9; x += 1) {
-        if (x === selected.x && y === selected.y) {
-          continue;
-        }
-
-        const baseMove: BoardMove = { from: selected, to: { x, y } };
-        const normal = applyMove(state, baseMove).ok;
-        const promote = applyMove(state, { ...baseMove, promote: true }).ok;
-
-        if (normal || promote) {
-          targets.push({ x, y });
-        }
-      }
-    }
-
-    return targets;
+    return generateLegalTargets(state, selected);
   }, [canOperateNow, selected, selectedDrop, state]);
 
   const legalTargetKeys = useMemo(() => {
@@ -738,13 +705,14 @@ export function App() {
   }, [legalTargets]);
 
   const appendMoveHistory = useCallback(
-    (move: Move) => {
-      const previousTo = moveHistory.length > 0 ? moveHistory[moveHistory.length - 1].to : null;
-      const text = formatMoveText(state, move, previousTo);
-      const moveNumber = moveHistory.length + 1;
-      setMoveHistory((prev) => [...prev, { id: moveNumber, text, to: move.to }]);
+    (baseState: GameState, move: Move) => {
+      setMoveHistory((prev) => {
+        const previousTo = prev.length > 0 ? prev[prev.length - 1].to : null;
+        const text = formatMoveText(baseState, move, previousTo);
+        return [...prev, { id: prev.length + 1, text, to: move.to }];
+      });
     },
-    [moveHistory, state],
+    [],
   );
 
   const playPieceSound = useCallback(() => {
@@ -756,12 +724,15 @@ export function App() {
   }, []);
 
   const resolveBotMatchOutcome = useCallback((nextState: GameState): boolean => {
-    const hasPlayableMove = generateLegalMoves(nextState).some((candidate) => applyMove(nextState, candidate).ok);
-    if (hasPlayableMove) {
+    if (hasAnyLegalMove(nextState)) {
+      setGameOver(false);
+      setShowRestartDialog(false);
+      setWinner(null);
+      setResultText(null);
       return false;
     }
 
-    if (isCheckmate(nextState)) {
+    if (isInCheck(nextState)) {
       const nextWinner = oppositeColor(nextState.turn);
       setWinner(nextWinner);
       setResultText(`${winnerLabel(nextWinner)}\u306e\u52dd\u3061\uff08\u8a70\u307f\uff09`);
@@ -775,19 +746,14 @@ export function App() {
     return true;
   }, []);
 
-  const submitMoveByBot = useCallback(
-    (move: Move) => {
-      if (screenMode !== "game" || matchMode !== "bot" || !canOperateNow) {
-        return;
-      }
-
-      const applied = applyMove(state, move);
+  const applyLocalMove = useCallback(
+    (baseState: GameState, move: Move): boolean => {
+      const applied = applyMove(baseState, move);
       if (!applied.ok) {
-        setGameMessage("\u4e0d\u6b63\u306a\u7740\u624b\u3067\u3059\u3002\u5165\u529b\u5185\u5bb9\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002");
-        return;
+        return false;
       }
 
-      appendMoveHistory(move);
+      appendMoveHistory(baseState, move);
       playPieceSound();
       setState(applied.value);
       setGameVersion((current) => {
@@ -796,16 +762,23 @@ export function App() {
         return next;
       });
       setGameMessage(null);
+      resolveBotMatchOutcome(applied.value);
+      return true;
+    },
+    [appendMoveHistory, playPieceSound, resolveBotMatchOutcome],
+  );
 
-      const ended = resolveBotMatchOutcome(applied.value);
-      if (!ended) {
-        setGameOver(false);
-        setShowRestartDialog(false);
-        setWinner(null);
-        setResultText(null);
+  const submitMoveByBot = useCallback(
+    (move: Move) => {
+      if (screenMode !== "game" || matchMode !== "bot" || !canOperateNow) {
+        return;
+      }
+
+      if (!applyLocalMove(state, move)) {
+        setGameMessage("\u4e0d\u6b63\u306a\u7740\u624b\u3067\u3059\u3002\u5165\u529b\u5185\u5bb9\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002");
       }
     },
-    [screenMode, matchMode, canOperateNow, state, appendMoveHistory, playPieceSound, resolveBotMatchOutcome],
+    [applyLocalMove, screenMode, matchMode, canOperateNow, state],
   );
 
   const submitMoveByApi = useCallback(
@@ -824,7 +797,7 @@ export function App() {
           move,
         });
 
-        appendMoveHistory(move);
+        appendMoveHistory(state, move);
         playPieceSound();
         applySnapshot(updated, { showDialog: true });
         setNetworkBannerMessage(null);
@@ -838,7 +811,7 @@ export function App() {
         setIsSubmittingMove(false);
       }
     },
-    [session, canOperateNow, gameVersion, appendMoveHistory, playPieceSound, applySnapshot, syncSnapshot, toGameErrorMessage],
+    [session, canOperateNow, gameVersion, appendMoveHistory, playPieceSound, applySnapshot, syncSnapshot, toGameErrorMessage, state],
   );
 
   const submitMoveByMode = useCallback(
@@ -933,41 +906,14 @@ export function App() {
     }
 
     const timerId = window.setTimeout(() => {
-      let selectedMove = chooseRandomMove(state);
-      if (selectedMove) {
-        const result = applyMove(state, selectedMove);
-        if (!result.ok) {
-          selectedMove = generateLegalMoves(state).find((candidate) => applyMove(state, candidate).ok) ?? null;
-        }
-      }
-
+      const selectedMove = chooseRandomMove(state);
       if (!selectedMove) {
         resolveBotMatchOutcome(state);
         return;
       }
 
-      const applied = applyMove(state, selectedMove);
-      if (!applied.ok) {
+      if (!applyLocalMove(state, selectedMove)) {
         setGameMessage("\u30dc\u30c3\u30c8\u306e\u7740\u624b\u751f\u6210\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002");
-        return;
-      }
-
-      appendMoveHistory(selectedMove);
-      playPieceSound();
-      setState(applied.value);
-      setGameVersion((current) => {
-        const next = current + 1;
-        latestVersionRef.current = next;
-        return next;
-      });
-      setGameMessage(null);
-
-      const ended = resolveBotMatchOutcome(applied.value);
-      if (!ended) {
-        setGameOver(false);
-        setShowRestartDialog(false);
-        setWinner(null);
-        setResultText(null);
       }
     }, 350);
 
@@ -985,8 +931,7 @@ export function App() {
     isSyncingSnapshot,
     botSeat,
     state,
-    appendMoveHistory,
-    playPieceSound,
+    applyLocalMove,
     resolveBotMatchOutcome,
   ]);
 
@@ -1006,19 +951,9 @@ export function App() {
     clearStoredSession();
     setSession(null);
     setSpectatorGameId(null);
-    setMoveHistory([]);
-    setWinner(null);
-    setResultText(null);
-    setGameOver(false);
-    setState(initialState);
-    setClockState(createClockState(initialTimeControl));
-    setClockTurnStartedAtMs(Date.now());
-    setClockNowMs(Date.now());
-    setGameVersion(1);
-    latestVersionRef.current = 1;
+    resetLocalGameState();
     replaceSpectateLocation(null);
-    clearSelections();
-  }, [clearSelections, initialState, initialTimeControl, replaceSpectateLocation]);
+  }, [replaceSpectateLocation, resetLocalGameState]);
 
   const resign = useCallback(async () => {
     if (screenMode !== "game" || gameOver || isPaused || isSubmittingResign || isSyncingSnapshot) {
@@ -1075,6 +1010,14 @@ export function App() {
     }
   }, [matchMode, onlineGameId, syncSnapshot]);
 
+  const displayClockState = useMemo(() => {
+    if (screenMode !== "game" || matchMode !== "online" || gameOver) {
+      return clockState;
+    }
+
+    return projectClockState(clockState, state.turn, clockTurnStartedAtMs, clockNowMs);
+  }, [screenMode, matchMode, gameOver, clockState, state.turn, clockTurnStartedAtMs, clockNowMs]);
+
   if (screenMode === "setup") {
     return (
       <SetupScreen
@@ -1125,14 +1068,6 @@ export function App() {
         : isSpectatorMode
           ? `観戦中: ${winnerLabel(state.turn)}の手番`
           : `手番: ${winnerLabel(state.turn)}`;
-
-  const displayClockState = useMemo(() => {
-    if (screenMode !== "game" || matchMode !== "online" || gameOver) {
-      return clockState;
-    }
-
-    return projectClockState(clockState, state.turn, clockTurnStartedAtMs, clockNowMs);
-  }, [screenMode, matchMode, gameOver, clockState, state.turn, clockTurnStartedAtMs, clockNowMs]);
 
   return (
     <main className="app">

--- a/core/src/checkmate.ts
+++ b/core/src/checkmate.ts
@@ -1,5 +1,5 @@
-﻿import { isInCheck } from "./check";
-import { generateLegalMoves } from "./moveGenerator";
+import { isInCheck } from "./check";
+import { hasAnyPseudoLegalMove } from "./moveGenerator";
 import { type GameState } from "./types";
 
 export function isCheckmate(state: GameState): boolean {
@@ -7,5 +7,5 @@ export function isCheckmate(state: GameState): boolean {
     return false;
   }
 
-  return generateLegalMoves(state).length === 0;
+  return !hasAnyPseudoLegalMove(state);
 }

--- a/core/src/moveGenerator.ts
+++ b/core/src/moveGenerator.ts
@@ -1,63 +1,436 @@
-﻿import { forEachBoardPosition } from "./board";
+import { forEachBoardPosition, isInsideBoard } from "./board";
+import { isInCheck } from "./check";
 import { HAND_PIECE_KINDS } from "./constants";
 import { tryApplyMove } from "./moveExecutor";
 import { canChoosePromotion, shouldAutoPromote } from "./promotion";
-import { type BoardMove, type Move, type GameState } from "./types";
+import { type BoardMove, type Color, type GameState, type Move, type Piece, type Position } from "./types";
 
-function pushIfApplicable(state: GameState, move: Move, moves: Move[]): void {
-  if (tryApplyMove(state, move).ok) {
-    moves.push(move);
+type Delta = {
+  dx: number;
+  dy: number;
+};
+
+function forwardDelta(color: Color): number {
+  return color === "black" ? -1 : 1;
+}
+
+function isGoldLikePiece(piece: Piece): boolean {
+  return (
+    piece.kind === "gold"
+    || (
+      piece.promoted
+      && (
+        piece.kind === "pawn"
+        || piece.kind === "lance"
+        || piece.kind === "knight"
+        || piece.kind === "silver"
+      )
+    )
+  );
+}
+
+function goldMoveDeltas(color: Color): readonly Delta[] {
+  const forward = forwardDelta(color);
+  return [
+    { dx: 0, dy: forward },
+    { dx: -1, dy: forward },
+    { dx: 1, dy: forward },
+    { dx: -1, dy: 0 },
+    { dx: 1, dy: 0 },
+    { dx: 0, dy: -forward },
+  ];
+}
+
+function silverMoveDeltas(color: Color): readonly Delta[] {
+  const forward = forwardDelta(color);
+  return [
+    { dx: 0, dy: forward },
+    { dx: -1, dy: forward },
+    { dx: 1, dy: forward },
+    { dx: -1, dy: -forward },
+    { dx: 1, dy: -forward },
+  ];
+}
+
+function knightMoveDeltas(color: Color): readonly Delta[] {
+  const forward = forwardDelta(color);
+  return [
+    { dx: -1, dy: forward * 2 },
+    { dx: 1, dy: forward * 2 },
+  ];
+}
+
+function addStepTargets(
+  state: GameState,
+  from: Position,
+  color: Color,
+  deltas: readonly Delta[],
+  targets: Position[],
+): void {
+  for (const { dx, dy } of deltas) {
+    const x = from.x + dx;
+    const y = from.y + dy;
+    if (!isInsideBoard(x, y)) {
+      continue;
+    }
+
+    const occupant = state.board[y][x];
+    if (occupant?.color === color) {
+      continue;
+    }
+
+    targets.push({ x, y });
   }
 }
 
-export function generateLegalMoves(state: GameState): Move[] {
-  const moves: Move[] = [];
+function addRayTargets(
+  state: GameState,
+  from: Position,
+  color: Color,
+  deltas: readonly Delta[],
+  targets: Position[],
+): void {
+  for (const { dx, dy } of deltas) {
+    let x = from.x + dx;
+    let y = from.y + dy;
 
-  forEachBoardPosition(({ x, y }) => {
-    const piece = state.board[y][x];
-    if (!piece || piece.color !== state.turn) {
-      return;
+    while (isInsideBoard(x, y)) {
+      const occupant = state.board[y][x];
+      if (!occupant) {
+        targets.push({ x, y });
+        x += dx;
+        y += dy;
+        continue;
+      }
+
+      if (occupant.color !== color) {
+        targets.push({ x, y });
+      }
+      break;
+    }
+  }
+}
+
+function collectBoardMoveTargets(state: GameState, from: Position): Position[] {
+  const piece = state.board[from.y]?.[from.x];
+  if (!piece || piece.color !== state.turn) {
+    return [];
+  }
+
+  const targets: Position[] = [];
+  if (isGoldLikePiece(piece)) {
+    addStepTargets(state, from, piece.color, goldMoveDeltas(piece.color), targets);
+    return targets;
+  }
+
+  switch (piece.kind) {
+    case "king":
+      addStepTargets(
+        state,
+        from,
+        piece.color,
+        [
+          { dx: -1, dy: -1 },
+          { dx: 0, dy: -1 },
+          { dx: 1, dy: -1 },
+          { dx: -1, dy: 0 },
+          { dx: 1, dy: 0 },
+          { dx: -1, dy: 1 },
+          { dx: 0, dy: 1 },
+          { dx: 1, dy: 1 },
+        ],
+        targets,
+      );
+      return targets;
+    case "silver":
+      addStepTargets(state, from, piece.color, silverMoveDeltas(piece.color), targets);
+      return targets;
+    case "knight":
+      addStepTargets(state, from, piece.color, knightMoveDeltas(piece.color), targets);
+      return targets;
+    case "pawn":
+      addStepTargets(state, from, piece.color, [{ dx: 0, dy: forwardDelta(piece.color) }], targets);
+      return targets;
+    case "lance":
+      addRayTargets(state, from, piece.color, [{ dx: 0, dy: forwardDelta(piece.color) }], targets);
+      return targets;
+    case "rook":
+      addRayTargets(
+        state,
+        from,
+        piece.color,
+        [
+          { dx: 0, dy: -1 },
+          { dx: -1, dy: 0 },
+          { dx: 1, dy: 0 },
+          { dx: 0, dy: 1 },
+        ],
+        targets,
+      );
+      if (piece.promoted) {
+        addStepTargets(
+          state,
+          from,
+          piece.color,
+          [
+            { dx: -1, dy: -1 },
+            { dx: 1, dy: -1 },
+            { dx: -1, dy: 1 },
+            { dx: 1, dy: 1 },
+          ],
+          targets,
+        );
+      }
+      return targets;
+    case "bishop":
+      addRayTargets(
+        state,
+        from,
+        piece.color,
+        [
+          { dx: -1, dy: -1 },
+          { dx: 1, dy: -1 },
+          { dx: -1, dy: 1 },
+          { dx: 1, dy: 1 },
+        ],
+        targets,
+      );
+      if (piece.promoted) {
+        addStepTargets(
+          state,
+          from,
+          piece.color,
+          [
+            { dx: 0, dy: -1 },
+            { dx: -1, dy: 0 },
+            { dx: 1, dy: 0 },
+            { dx: 0, dy: 1 },
+          ],
+          targets,
+        );
+      }
+      return targets;
+    case "gold":
+      addStepTargets(state, from, piece.color, goldMoveDeltas(piece.color), targets);
+      return targets;
+  }
+}
+
+function hasUnpromotedPawnInFile(state: GameState, fileX: number): boolean {
+  for (const row of state.board) {
+    const piece = row[fileX];
+    if (piece?.kind === "pawn" && piece.color === state.turn && !piece.promoted) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function canDropOnRank(pieceKind: Piece["kind"], color: Color, y: number): boolean {
+  if (pieceKind === "pawn" || pieceKind === "lance") {
+    return color === "black" ? y > 0 : y < 8;
+  }
+
+  if (pieceKind === "knight") {
+    return color === "black" ? y > 1 : y < 7;
+  }
+
+  return true;
+}
+
+function isPawnDrop(move: Move): move is Extract<Move, { drop: Piece["kind"] }> {
+  return "drop" in move && move.drop === "pawn";
+}
+
+function visitCandidateMoves(
+  state: GameState,
+  from: Position,
+  visitor: (move: Move) => void | false,
+  excludePawnDropMate: boolean,
+): boolean {
+  const piece = state.board[from.y]?.[from.x];
+  if (!piece || piece.color !== state.turn) {
+    return true;
+  }
+
+  for (const to of collectBoardMoveTargets(state, from)) {
+    const baseMove: BoardMove = { from, to };
+    if (visitMoveIfApplicable(state, baseMove, visitor, excludePawnDropMate) === false) {
+      return false;
     }
 
-    forEachBoardPosition(({ x: toX, y: toY }) => {
-      if (x === toX && y === toY) {
-        return;
+    if (!piece.promoted && canChoosePromotion(piece, baseMove) && !shouldAutoPromote(piece, baseMove)) {
+      const promoteMove: BoardMove = { ...baseMove, promote: true };
+      if (visitMoveIfApplicable(state, promoteMove, visitor, excludePawnDropMate) === false) {
+        return false;
       }
+    }
+  }
 
-      const baseMove: BoardMove = {
-        from: { x, y },
-        to: { x: toX, y: toY },
-      };
+  return true;
+}
 
-      pushIfApplicable(state, baseMove, moves);
+function isPseudoCheckmate(state: GameState): boolean {
+  return isInCheck(state) && !hasAnyPseudoLegalMove(state);
+}
 
-      if (!piece.promoted && canChoosePromotion(piece, baseMove) && !shouldAutoPromote(piece, baseMove)) {
-        pushIfApplicable(state, { ...baseMove, promote: true }, moves);
-      }
-    });
-  });
+function isGeneratedMoveLegal(state: GameState, move: Move, excludePawnDropMate: boolean): boolean {
+  const result = tryApplyMove(state, move);
+  if (!result.ok) {
+    return false;
+  }
 
+  if (excludePawnDropMate && isPawnDrop(move) && isPseudoCheckmate(result.value)) {
+    return false;
+  }
+
+  return true;
+}
+
+function visitMoveIfApplicable(
+  state: GameState,
+  move: Move,
+  visitor: (move: Move) => void | false,
+  excludePawnDropMate: boolean,
+): void | false {
+  if (!isGeneratedMoveLegal(state, move, excludePawnDropMate)) {
+    return;
+  }
+
+  return visitor(move);
+}
+
+function visitLegalBoardMoves(
+  state: GameState,
+  from: Position,
+  visitor: (move: Move) => void | false,
+  excludePawnDropMate: boolean,
+): boolean {
+  return visitCandidateMoves(state, from, visitor, excludePawnDropMate);
+}
+
+function visitLegalDropMoves(
+  state: GameState,
+  visitor: (move: Move) => void | false,
+  excludePawnDropMate: boolean,
+): boolean {
   const hand = state.hands[state.turn];
+  let completed = true;
+
   for (const kind of HAND_PIECE_KINDS) {
     if ((hand[kind] ?? 0) <= 0) {
       continue;
     }
 
     forEachBoardPosition(({ x, y }) => {
-      pushIfApplicable(
-        state,
-        {
-          drop: kind,
-          to: { x, y },
-        },
-        moves,
-      );
+      if (state.board[y][x]) {
+        return;
+      }
+      if (!canDropOnRank(kind, state.turn, y)) {
+        return;
+      }
+      if (kind === "pawn" && hasUnpromotedPawnInFile(state, x)) {
+        return;
+      }
+
+      const move: Move = {
+        drop: kind,
+        to: { x, y },
+      };
+
+      if (visitMoveIfApplicable(state, move, visitor, excludePawnDropMate) === false) {
+        completed = false;
+        return false;
+      }
     });
+
+    if (!completed) {
+      return false;
+    }
   }
 
+  return true;
+}
+
+function visitLegalMoves(
+  state: GameState,
+  visitor: (move: Move) => void | false,
+  excludePawnDropMate: boolean,
+): boolean {
+  let completed = true;
+
+  forEachBoardPosition((position) => {
+    const piece = state.board[position.y][position.x];
+    if (!piece || piece.color !== state.turn) {
+      return;
+    }
+
+    if (!visitLegalBoardMoves(state, position, visitor, excludePawnDropMate)) {
+      completed = false;
+      return false;
+    }
+  });
+
+  if (!completed) {
+    return false;
+  }
+
+  return visitLegalDropMoves(state, visitor, excludePawnDropMate);
+}
+
+export function generateLegalMoves(state: GameState): Move[] {
+  const moves: Move[] = [];
+  visitLegalMoves(state, (move) => {
+    moves.push(move);
+  }, true);
   return moves;
 }
 
 export function generatePseudoLegalMoves(state: GameState): Move[] {
-  return generateLegalMoves(state);
+  const moves: Move[] = [];
+  visitLegalMoves(state, (move) => {
+    moves.push(move);
+  }, false);
+  return moves;
+}
+
+export function hasAnyLegalMove(state: GameState): boolean {
+  let found = false;
+  visitLegalMoves(state, () => {
+    found = true;
+    return false;
+  }, true);
+  return found;
+}
+
+export function hasAnyPseudoLegalMove(state: GameState): boolean {
+  let found = false;
+  visitLegalMoves(state, () => {
+    found = true;
+    return false;
+  }, false);
+  return found;
+}
+
+export function generateLegalTargets(state: GameState, from: Position): Position[] {
+  const targets: Position[] = [];
+  const piece = state.board[from.y]?.[from.x];
+  if (!piece || piece.color !== state.turn) {
+    return targets;
+  }
+
+  for (const to of collectBoardMoveTargets(state, from)) {
+    const baseMove: BoardMove = { from, to };
+    const canMoveNormally = isGeneratedMoveLegal(state, baseMove, true);
+    const canMoveWithPromotion = !piece.promoted
+      && canChoosePromotion(piece, baseMove)
+      && !shouldAutoPromote(piece, baseMove)
+      && isGeneratedMoveLegal(state, { ...baseMove, promote: true }, true);
+
+    if (canMoveNormally || canMoveWithPromotion) {
+      targets.push(to);
+    }
+  }
+
+  return targets;
 }

--- a/core/tests/moveGenerator.test.ts
+++ b/core/tests/moveGenerator.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, test } from "vitest";
 import { applyMove } from "../src/applyMove";
 import { createInitialGameState } from "../src/initialPosition";
+import { type GameState, type Piece } from "../src/types";
 import { generateLegalMoves } from "../src/moveGenerator";
+
+function createEmptyState(turn: GameState["turn"] = "black"): GameState {
+  return {
+    board: Array.from({ length: 9 }, () => Array.from({ length: 9 }, () => null)),
+    hands: { black: {}, white: {} },
+    turn,
+  };
+}
+
+function piece(kind: Piece["kind"], color: Piece["color"], promoted = false): Piece {
+  return { kind, color, promoted };
+}
 
 describe("generateLegalMoves", () => {
   test("returns legal moves for current state", () => {
@@ -21,5 +34,18 @@ describe("generateLegalMoves", () => {
     const signatures = new Set(moves.map((move) => JSON.stringify(move)));
 
     expect(signatures.size).toBe(moves.length);
+  });
+
+  test("excludes pawn-drop mate from generated legal moves", () => {
+    const state = createEmptyState("black");
+    state.hands.black.pawn = 1;
+    state.board[8][8] = piece("king", "black");
+    state.board[0][0] = piece("king", "white");
+    state.board[0][1] = piece("lance", "white");
+    state.board[1][2] = piece("rook", "black");
+
+    const moves = generateLegalMoves(state);
+
+    expect(moves).not.toContainEqual({ drop: "pawn", to: { x: 0, y: 1 } });
   });
 });

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -107,6 +107,14 @@ export interface GameStore {
 const DEFAULT_MATCH_MAIN_MINUTES = 10;
 const DEFAULT_MATCH_BYO_SECONDS = 30;
 
+type InitialPersistedGameInput = {
+  gameId?: string;
+  nowMs: number;
+  mainMinutes: number;
+  byoSeconds: number;
+  joinTokenHash?: string;
+};
+
 function toIsoNow(): string {
   return new Date().toISOString();
 }
@@ -154,6 +162,30 @@ function oppositeSeat(seat: Seat): Seat {
   return seat === "black" ? "white" : "black";
 }
 
+function createInitialPersistedGame(input: InitialPersistedGameInput): PersistedGame {
+  const id = input.gameId ?? randomUUID();
+  const nowIso = new Date(input.nowMs).toISOString();
+  const initialState = createInitialGameState();
+
+  return {
+    id,
+    status: "waiting",
+    turn: "black",
+    state: initialState,
+    mainSecondsBlack: input.mainMinutes * 60,
+    mainSecondsWhite: input.mainMinutes * 60,
+    byoSecondsBlack: input.byoSeconds,
+    byoSecondsWhite: input.byoSeconds,
+    resultType: null,
+    winner: null,
+    version: 1,
+    turnStartedAtMs: input.nowMs,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    joinTokenHash: input.joinTokenHash ?? "",
+  };
+}
+
 type TurnClockProjection = {
   remainingMainSeconds: number;
   remainingByoSeconds: number;
@@ -198,6 +230,32 @@ function projectTurnClock(mainSeconds: number, byoSeconds: number, elapsedSecond
   };
 }
 
+function projectCurrentTurnClock(game: PersistedGame, elapsedSeconds: number): TurnClockProjection {
+  return game.turn === "black"
+    ? projectTurnClock(game.mainSecondsBlack, game.byoSecondsBlack, elapsedSeconds)
+    : projectTurnClock(game.mainSecondsWhite, game.byoSecondsWhite, elapsedSeconds);
+}
+
+function applyTurnClockProjection(game: PersistedGame, projected: TurnClockProjection, elapsedSeconds: number): void {
+  if (game.turn === "black") {
+    game.mainSecondsBlack = projected.remainingMainSeconds;
+    game.byoSecondsBlack = projected.remainingByoSeconds;
+  } else {
+    game.mainSecondsWhite = projected.remainingMainSeconds;
+    game.byoSecondsWhite = projected.remainingByoSeconds;
+  }
+
+  game.turnStartedAtMs += elapsedSeconds * 1000;
+}
+
+function markTimedOutGame(game: PersistedGame, nowMs: number): void {
+  game.status = "finished";
+  game.resultType = "timeout";
+  game.winner = oppositeSeat(game.turn);
+  game.updatedAt = new Date(nowMs).toISOString();
+  game.version += 1;
+}
+
 function projectClockForSnapshot(game: PersistedGame, nowMs: number): SnapshotClockProjection {
   const base: SnapshotClockProjection = {
     mainSecondsBlack: game.mainSecondsBlack,
@@ -217,25 +275,22 @@ function projectClockForSnapshot(game: PersistedGame, nowMs: number): SnapshotCl
     return base;
   }
 
-  if (game.turn === "black") {
-    const projected = projectTurnClock(game.mainSecondsBlack, game.byoSecondsBlack, elapsedSeconds);
-    return {
-      ...base,
-      mainSecondsBlack: projected.remainingMainSeconds,
-      byoSecondsBlack: projected.remainingByoSeconds,
-      turnStartedAtMs: game.turnStartedAtMs + elapsedSeconds * 1000,
-      timedOut: projected.timedOut,
-    };
-  }
-
-  const projected = projectTurnClock(game.mainSecondsWhite, game.byoSecondsWhite, elapsedSeconds);
-  return {
+  const projected = projectCurrentTurnClock(game, elapsedSeconds);
+  const snapshot: SnapshotClockProjection = {
     ...base,
-    mainSecondsWhite: projected.remainingMainSeconds,
-    byoSecondsWhite: projected.remainingByoSeconds,
     turnStartedAtMs: game.turnStartedAtMs + elapsedSeconds * 1000,
     timedOut: projected.timedOut,
   };
+
+  if (game.turn === "black") {
+    snapshot.mainSecondsBlack = projected.remainingMainSeconds;
+    snapshot.byoSecondsBlack = projected.remainingByoSeconds;
+  } else {
+    snapshot.mainSecondsWhite = projected.remainingMainSeconds;
+    snapshot.byoSecondsWhite = projected.remainingByoSeconds;
+  }
+
+  return snapshot;
 }
 
 function consumeElapsedClock(game: PersistedGame, nowMs: number): boolean {
@@ -248,27 +303,13 @@ function consumeElapsedClock(game: PersistedGame, nowMs: number): boolean {
     return false;
   }
 
-  if (game.turn === "black") {
-    const projected = projectTurnClock(game.mainSecondsBlack, game.byoSecondsBlack, elapsedSeconds);
-    game.mainSecondsBlack = projected.remainingMainSeconds;
-    game.turnStartedAtMs += elapsedSeconds * 1000;
-    if (!projected.timedOut) {
-      return false;
-    }
-  } else {
-    const projected = projectTurnClock(game.mainSecondsWhite, game.byoSecondsWhite, elapsedSeconds);
-    game.mainSecondsWhite = projected.remainingMainSeconds;
-    game.turnStartedAtMs += elapsedSeconds * 1000;
-    if (!projected.timedOut) {
-      return false;
-    }
+  const projected = projectCurrentTurnClock(game, elapsedSeconds);
+  applyTurnClockProjection(game, projected, elapsedSeconds);
+  if (!projected.timedOut) {
+    return false;
   }
 
-  game.status = "finished";
-  game.resultType = "timeout";
-  game.winner = oppositeSeat(game.turn);
-  game.updatedAt = new Date(nowMs).toISOString();
-  game.version += 1;
+  markTimedOutGame(game, nowMs);
   return true;
 }
 
@@ -280,12 +321,10 @@ function settleTimeoutIfNeeded(game: PersistedGame, nowMs: number): boolean {
 
   game.mainSecondsBlack = projected.mainSecondsBlack;
   game.mainSecondsWhite = projected.mainSecondsWhite;
+  game.byoSecondsBlack = projected.byoSecondsBlack;
+  game.byoSecondsWhite = projected.byoSecondsWhite;
   game.turnStartedAtMs = projected.turnStartedAtMs;
-  game.status = "finished";
-  game.resultType = "timeout";
-  game.winner = oppositeSeat(game.turn);
-  game.updatedAt = new Date(nowMs).toISOString();
-  game.version += 1;
+  markTimedOutGame(game, nowMs);
   return true;
 }
 
@@ -437,6 +476,8 @@ export class InMemoryStore implements GameStore {
 
     game.mainSecondsBlack = snapshot.mainSecondsBlack;
     game.mainSecondsWhite = snapshot.mainSecondsWhite;
+    game.byoSecondsBlack = snapshot.byoSecondsBlack;
+    game.byoSecondsWhite = snapshot.byoSecondsWhite;
     game.turnStartedAtMs = snapshot.turnStartedAtMs;
     game.status = snapshot.status;
     game.resultType = snapshot.resultType;
@@ -451,6 +492,8 @@ export class InMemoryStore implements GameStore {
 
     game.mainSecondsBlack = snapshot.mainSecondsBlack;
     game.mainSecondsWhite = snapshot.mainSecondsWhite;
+    game.byoSecondsBlack = snapshot.byoSecondsBlack;
+    game.byoSecondsWhite = snapshot.byoSecondsWhite;
     game.turnStartedAtMs = snapshot.turnStartedAtMs;
     if (snapshot.status === "finished") {
       game.status = snapshot.status;
@@ -464,24 +507,14 @@ export class InMemoryStore implements GameStore {
   async createGame(input: CreateGameInput): Promise<{ gameId: string; joinToken: string }> {
     const gameId = randomUUID();
     const nowMs = Date.now();
-    const nowIso = new Date(nowMs).toISOString();
-
-    this.games.set(gameId, {
-      id: gameId,
-      status: "waiting",
-      turn: "black",
-      state: createInitialGameState(),
-      mainSecondsBlack: input.mainMinutes * 60,
-      mainSecondsWhite: input.mainMinutes * 60,
-      byoSecondsBlack: input.byoSeconds,
-      byoSecondsWhite: input.byoSeconds,
-      resultType: null,
-      winner: null,
-      version: 1,
-      turnStartedAtMs: nowMs,
-      createdAt: nowIso,
-      updatedAt: nowIso,
+    const snapshot = createInitialPersistedGame({
+      gameId,
+      nowMs,
+      mainMinutes: input.mainMinutes,
+      byoSeconds: input.byoSeconds,
     });
+
+    this.games.set(gameId, toGame(snapshot));
 
     const joinToken = createJoinToken();
     this.joinTokens.set(gameId, joinToken);
@@ -819,10 +852,13 @@ export class PostgresStore implements GameStore {
   }
 
   private async createMatchGame(client: Queryable, passphraseHash: string): Promise<PersistedGame> {
-    const gameId = randomUUID();
     const nowMs = Date.now();
-    const nowIso = new Date(nowMs).toISOString();
-    const mainSeconds = DEFAULT_MATCH_MAIN_MINUTES * 60;
+    const snapshot = createInitialPersistedGame({
+      nowMs,
+      mainMinutes: DEFAULT_MATCH_MAIN_MINUTES,
+      byoSeconds: DEFAULT_MATCH_BYO_SECONDS,
+      joinTokenHash: passphraseHash,
+    });
 
     await client.query(
       `INSERT INTO games (
@@ -845,33 +881,17 @@ export class PostgresStore implements GameStore {
          $1, 'waiting', 'black', $2::jsonb, $3, $3, $4, $4, NULL, NULL, 1, $5, $6, $7, $7
        )`,
       [
-        gameId,
-        JSON.stringify(createInitialGameState()),
-        mainSeconds,
-        DEFAULT_MATCH_BYO_SECONDS,
-        passphraseHash,
-        nowMs,
-        nowIso,
+        snapshot.id,
+        JSON.stringify(snapshot.state),
+        snapshot.mainSecondsBlack,
+        snapshot.byoSecondsBlack,
+        snapshot.joinTokenHash,
+        snapshot.turnStartedAtMs,
+        snapshot.createdAt,
       ],
     );
 
-    return {
-      id: gameId,
-      status: "waiting",
-      turn: "black",
-      state: createInitialGameState(),
-      mainSecondsBlack: mainSeconds,
-      mainSecondsWhite: mainSeconds,
-      byoSecondsBlack: DEFAULT_MATCH_BYO_SECONDS,
-      byoSecondsWhite: DEFAULT_MATCH_BYO_SECONDS,
-      resultType: null,
-      winner: null,
-      version: 1,
-      turnStartedAtMs: nowMs,
-      createdAt: nowIso,
-      updatedAt: nowIso,
-      joinTokenHash: passphraseHash,
-    };
+    return snapshot;
   }
 
   private async updateGame(client: Queryable, game: PersistedGame, previousVersion: number): Promise<void> {
@@ -919,7 +939,13 @@ export class PostgresStore implements GameStore {
     const gameId = randomUUID();
     const joinToken = createJoinToken();
     const nowMs = Date.now();
-    const nowIso = new Date(nowMs).toISOString();
+    const snapshot = createInitialPersistedGame({
+      gameId,
+      nowMs,
+      mainMinutes: input.mainMinutes,
+      byoSeconds: input.byoSeconds,
+      joinTokenHash: hashToken(joinToken),
+    });
 
     await this.pool.query(
       `INSERT INTO games (
@@ -942,13 +968,13 @@ export class PostgresStore implements GameStore {
          $1, 'waiting', 'black', $2::jsonb, $3, $3, $4, $4, NULL, NULL, 1, $5, $6, $7, $7
        )`,
       [
-        gameId,
-        JSON.stringify(createInitialGameState()),
-        input.mainMinutes * 60,
-        input.byoSeconds,
-        hashToken(joinToken),
-        nowMs,
-        nowIso,
+        snapshot.id,
+        JSON.stringify(snapshot.state),
+        snapshot.mainSecondsBlack,
+        snapshot.byoSecondsBlack,
+        snapshot.joinTokenHash,
+        snapshot.turnStartedAtMs,
+        snapshot.createdAt,
       ],
     );
 

--- a/server/tests/postgresStore.test.ts
+++ b/server/tests/postgresStore.test.ts
@@ -149,4 +149,49 @@ describe("PostgresStore", () => {
 
     nowSpy.mockRestore();
   });
+
+  test("deducts byo-yomi on submitMove after main time is exhausted", async () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(1_000_000);
+
+    const store = new PostgresStore(pool);
+    const created = await store.createGame({ mainMinutes: 0, byoSeconds: 30 });
+    const black = await store.joinGame(created.gameId, {
+      name: "black",
+      seat: "black",
+      joinToken: created.joinToken,
+    });
+    await store.joinGame(created.gameId, {
+      name: "white",
+      seat: "white",
+      joinToken: created.joinToken,
+    });
+
+    const game = await store.getGame(created.gameId);
+    expect(game).not.toBeNull();
+    if (!game) {
+      nowSpy.mockRestore();
+      return;
+    }
+
+    const actor = await store.findPlayerByGuestId(created.gameId, black.guestId);
+    expect(actor).not.toBeNull();
+    if (!actor) {
+      nowSpy.mockRestore();
+      return;
+    }
+
+    nowSpy.mockReturnValue(1_005_000);
+    const updated = await store.submitMove(
+      created.gameId,
+      actor,
+      { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },
+      game.version,
+    );
+
+    expect(updated.mainSecondsBlack).toBe(0);
+    expect(updated.byoSecondsBlack).toBe(25);
+
+    nowSpy.mockRestore();
+  });
 });

--- a/server/tests/storeClock.test.ts
+++ b/server/tests/storeClock.test.ts
@@ -121,4 +121,49 @@ describe("InMemoryStore clock handling", () => {
 
     nowSpy.mockRestore();
   });
+
+  test("deducts byo-yomi on submitMove after main time is exhausted", async () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(1_000_000);
+
+    const store = new InMemoryStore();
+    const created = await store.createGame({ mainMinutes: 0, byoSeconds: 30 });
+    const black = await store.joinGame(created.gameId, {
+      name: "black",
+      seat: "black",
+      joinToken: created.joinToken,
+    });
+    await store.joinGame(created.gameId, {
+      name: "white",
+      seat: "white",
+      joinToken: created.joinToken,
+    });
+
+    const game = await store.getGame(created.gameId);
+    expect(game).not.toBeNull();
+    if (!game) {
+      nowSpy.mockRestore();
+      return;
+    }
+
+    const actor = await store.findPlayerByGuestId(created.gameId, black.guestId);
+    expect(actor).not.toBeNull();
+    if (!actor) {
+      nowSpy.mockRestore();
+      return;
+    }
+
+    nowSpy.mockReturnValue(1_005_000);
+    const updated = await store.submitMove(
+      created.gameId,
+      actor,
+      { from: { x: 0, y: 6 }, to: { x: 0, y: 5 } },
+      game.version,
+    );
+
+    expect(updated.mainSecondsBlack).toBe(0);
+    expect(updated.byoSecondsBlack).toBe(25);
+
+    nowSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## 概要
- 合法手生成を候補ベースへ整理し、打ち歩詰めが合法手一覧へ混ざる不整合を修正
- App のローカル対局状態リセットとローカル着手反映を共通化し、合法手ハイライトを core に集約
- InMemory/Postgres ストアの時計処理を整理し、秒読み消費が submitMove で欠落する不具合を修正

## テスト
- npm run test
- npm run build
