### PR TITLE
リファクタリング: プロジェクト全体のDRY改善

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -136,6 +136,25 @@ export function App() {
     setPendingPromotion(null);
   }, []);
 
+  const resetGameRuntimeState = useCallback(() => {
+    const now = Date.now();
+    setState(initialState);
+    setClockState(createClockState(initialTimeControl));
+    setClockTurnStartedAtMs(now);
+    setClockNowMs(now);
+    setGameVersion(1);
+    latestVersionRef.current = 1;
+    setMoveHistory([]);
+    setWinner(null);
+    setResultText(null);
+    setGameOver(false);
+    setShowRestartDialog(false);
+    setIsPaused(false);
+    setGameMessage(null);
+    setNetworkBannerMessage(null);
+    clearSelections();
+  }, [clearSelections, initialState, initialTimeControl]);
+
   const onSetupModeChange = useCallback((mode: MatchMode) => {
     setSetupMode(mode);
     setJoinErrors([]);
@@ -422,21 +441,7 @@ export function App() {
       setMatchMode("online");
       setSetupMode("online");
       setScreenMode("game");
-      setIsPaused(false);
-      setMoveHistory([]);
-      setWinner(null);
-      setResultText(null);
-      setGameOver(false);
-      setShowRestartDialog(false);
-      setGameMessage(null);
-      setNetworkBannerMessage(null);
-      setState(initialState);
-      setClockState(createClockState(initialTimeControl));
-      setClockTurnStartedAtMs(Date.now());
-      setClockNowMs(Date.now());
-      setGameVersion(1);
-      latestVersionRef.current = 1;
-      clearSelections();
+      resetGameRuntimeState();
 
       const synced = await syncSnapshot(gameId, { showDialog: false });
       if (!synced) {
@@ -455,7 +460,7 @@ export function App() {
     } finally {
       setIsStartingSpectate(false);
     }
-  }, [clearSelections, initialState, initialTimeControl, replaceSpectateLocation, syncSnapshot]);
+  }, [replaceSpectateLocation, resetGameRuntimeState, syncSnapshot]);
 
   const onStartSpectate = useCallback(async () => {
     const validated = validateSpectateGameForm({ gameId: spectateGameId });
@@ -492,29 +497,15 @@ export function App() {
       setSpectatorGameId(null);
       setMatchMode("bot");
       setScreenMode("game");
-      setState(initialState);
-      setClockState(createClockState(initialTimeControl));
-      setClockTurnStartedAtMs(Date.now());
-      setClockNowMs(Date.now());
-      setGameVersion(1);
-      latestVersionRef.current = 1;
-      setWinner(null);
-      setResultText(null);
-      setGameOver(false);
-      setShowRestartDialog(false);
-      setIsPaused(false);
-      setMoveHistory([]);
-      setGameMessage(null);
-      setNetworkBannerMessage(null);
+      resetGameRuntimeState();
       setBotMessage(null);
       setSpectateMessage(null);
       setSpectateErrors([]);
       replaceSpectateLocation(null);
-      clearSelections();
     } finally {
       setIsStartingBot(false);
     }
-  }, [botName, botSeat, clearSelections, initialState, initialTimeControl, replaceSpectateLocation]);
+  }, [botName, botSeat, replaceSpectateLocation, resetGameRuntimeState]);
 
   useEffect(() => {
     if (!initialSpectateGameId || hasAutoStartedSpectateRef.current) {
@@ -994,10 +985,6 @@ export function App() {
     setScreenMode("setup");
     setSetupMode("online");
     setMatchMode("online");
-    setShowRestartDialog(false);
-    setIsPaused(false);
-    setGameMessage(null);
-    setNetworkBannerMessage(null);
     setBotMessage(null);
     setSpectateMessage(null);
     setSpectateErrors([]);
@@ -1006,19 +993,9 @@ export function App() {
     clearStoredSession();
     setSession(null);
     setSpectatorGameId(null);
-    setMoveHistory([]);
-    setWinner(null);
-    setResultText(null);
-    setGameOver(false);
-    setState(initialState);
-    setClockState(createClockState(initialTimeControl));
-    setClockTurnStartedAtMs(Date.now());
-    setClockNowMs(Date.now());
-    setGameVersion(1);
-    latestVersionRef.current = 1;
+    resetGameRuntimeState();
     replaceSpectateLocation(null);
-    clearSelections();
-  }, [clearSelections, initialState, initialTimeControl, replaceSpectateLocation]);
+  }, [replaceSpectateLocation, resetGameRuntimeState]);
 
   const resign = useCallback(async () => {
     if (screenMode !== "game" || gameOver || isPaused || isSubmittingResign || isSyncingSnapshot) {

--- a/app/src/online/lobbyValidation.ts
+++ b/app/src/online/lobbyValidation.ts
@@ -1,6 +1,6 @@
-type Seat = "black" | "white";
+import { isValidLobbyPassphrase, isValidPlayerName } from "../../../core/src/lobbyRules";
 
-const PASS_PHRASE_PATTERN = /^[A-Za-z0-9]{1,8}$/;
+type Seat = "black" | "white";
 
 export type CreateGameFormInput = {
   mainMinutes: string;
@@ -43,11 +43,6 @@ function toInteger(value: string): number | null {
   return Number.isInteger(parsed) ? parsed : null;
 }
 
-function hasValidName(name: string): boolean {
-  const trimmed = name.trim();
-  return trimmed.length >= 2 && trimmed.length <= 20;
-}
-
 export function validateCreateGameForm(input: CreateGameFormInput): ValidationResult<{ mainMinutes: number; byoSeconds: number }> {
   const errors: string[] = [];
   const mainMinutes = toInteger(input.mainMinutes);
@@ -87,7 +82,7 @@ export function validateJoinGameForm(
   if (!joinToken) {
     errors.push("joinTokenを入力してください。");
   }
-  if (!hasValidName(name)) {
+  if (!isValidPlayerName(name)) {
     errors.push("表示名は2〜20文字で入力してください。");
   }
 
@@ -113,11 +108,11 @@ export function validateMatchLobbyForm(input: MatchLobbyFormInput): ValidationRe
 
   if (!passphrase) {
     errors.push("合言葉を入力してください。");
-  } else if (!PASS_PHRASE_PATTERN.test(passphrase)) {
+  } else if (!isValidLobbyPassphrase(passphrase)) {
     errors.push("合言葉は半角英数字8文字以内で入力してください。");
   }
 
-  if (!hasValidName(name)) {
+  if (!isValidPlayerName(name)) {
     errors.push("表示名は2〜20文字で入力してください。");
   }
 

--- a/app/tests/appTitleUi.test.ts
+++ b/app/tests/appTitleUi.test.ts
@@ -1,12 +1,5 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
-
-function readSource(relativePath: string): string {
-  return readFileSync(join(process.cwd(), relativePath), "utf8")
-    .replace(/^\uFEFF/, "")
-    .replace(/\r\n/g, "\n");
-}
+import { readSource } from "./support/sourceReader";
 
 describe("application title", () => {
   test("uses 将棋倶楽部2.4 in UI headings and html title", () => {

--- a/app/tests/boardStabilityCss.test.ts
+++ b/app/tests/boardStabilityCss.test.ts
@@ -1,14 +1,9 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
-
-function readGlobalCss(): string {
-  return readFileSync(join(process.cwd(), "app/src/styles/globals.css"), "utf8");
-}
+import { readSource } from "./support/sourceReader";
 
 describe("board stability css", () => {
   test("keeps move history viewport height fixed to avoid move-time layout shifts", () => {
-    const css = readGlobalCss().replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+    const css = readSource("app/src/styles/globals.css");
     const match = css.match(/\.history-list\s*\{([\s\S]*?)\}/);
     expect(match).not.toBeNull();
     const block = match?.[1] ?? "";

--- a/app/tests/botClockUi.test.ts
+++ b/app/tests/botClockUi.test.ts
@@ -1,12 +1,5 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
-
-function readSource(relativePath: string): string {
-  return readFileSync(join(process.cwd(), relativePath), "utf8")
-    .replace(/^\uFEFF/, "")
-    .replace(/\r\n/g, "\n");
-}
+import { readSource } from "./support/sourceReader";
 
 describe("bot clock UI", () => {
   test("renders both clock panels only in online mode", () => {

--- a/app/tests/gameSummaryUi.test.ts
+++ b/app/tests/gameSummaryUi.test.ts
@@ -1,12 +1,5 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
-
-function readSource(relativePath: string): string {
-  return readFileSync(join(process.cwd(), relativePath), "utf8")
-    .replace(/^\uFEFF/, "")
-    .replace(/\r\n/g, "\n");
-}
+import { readSource } from "./support/sourceReader";
 
 describe("game summary UI", () => {
   test("does not render the title-under summary row", () => {

--- a/app/tests/layoutCss.test.ts
+++ b/app/tests/layoutCss.test.ts
@@ -1,14 +1,9 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
-
-function readGlobalCss(): string {
-  return readFileSync(join(process.cwd(), "app/src/styles/globals.css"), "utf8");
-}
+import { readSource } from "./support/sourceReader";
 
 describe("game layout css", () => {
   test("keeps board and hand anchors fixed even on narrow screens", () => {
-    const css = readGlobalCss().replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+    const css = readSource("app/src/styles/globals.css");
     expect(css).toMatch(/\.hand-anchor\s*\{[\s\S]*?position:\s*absolute;/);
 
     const narrowMediaStart = css.indexOf("@media (max-width: 980px) {");

--- a/app/tests/seatNotationUi.test.ts
+++ b/app/tests/seatNotationUi.test.ts
@@ -1,12 +1,5 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
-
-function readSource(relativePath: string): string {
-  return readFileSync(join(process.cwd(), relativePath), "utf8")
-    .replace(/^\uFEFF/, "")
-    .replace(/\r\n/g, "\n");
-}
+import { readSource } from "./support/sourceReader";
 
 describe("UI seat notation", () => {
   test("uses 先手/後手 labels instead of Black/White in setup UI", () => {

--- a/app/tests/support/sourceReader.ts
+++ b/app/tests/support/sourceReader.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function normalizeSource(source: string): string {
+  return source.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+}
+
+export function readSource(relativePath: string): string {
+  return normalizeSource(readFileSync(join(process.cwd(), relativePath), "utf8"));
+}

--- a/core/src/lobbyRules.ts
+++ b/core/src/lobbyRules.ts
@@ -1,0 +1,17 @@
+export const MIN_PLAYER_NAME_LENGTH = 2;
+export const MAX_PLAYER_NAME_LENGTH = 20;
+export const MAX_LOBBY_PASSPHRASE_LENGTH = 8;
+
+const LOBBY_PASSPHRASE_PATTERN = /^[A-Za-z0-9]+$/;
+
+export function isValidPlayerName(name: string): boolean {
+  const trimmed = name.trim();
+  return trimmed.length >= MIN_PLAYER_NAME_LENGTH && trimmed.length <= MAX_PLAYER_NAME_LENGTH;
+}
+
+export function isValidLobbyPassphrase(passphrase: string): boolean {
+  const trimmed = passphrase.trim();
+  return trimmed.length > 0
+    && trimmed.length <= MAX_LOBBY_PASSPHRASE_LENGTH
+    && LOBBY_PASSPHRASE_PATTERN.test(trimmed);
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,5 +1,4 @@
-import type { GameState } from "../../core/src/types";
-import type { Move } from "../../core/src/types";
+import type { GameState, Move } from "../../core/src/types";
 
 export type Seat = "black" | "white";
 export type GameStatus = "waiting" | "active" | "finished";

--- a/server/src/validators.ts
+++ b/server/src/validators.ts
@@ -1,3 +1,5 @@
+import { BOARD_SIZE, HAND_PIECE_KINDS } from "../../core/src/constants";
+import { isValidLobbyPassphrase, isValidPlayerName } from "../../core/src/lobbyRules";
 import type { Move } from "../../core/src/types";
 import type { CreateGameInput, JoinGameInput, LobbyMatchInput } from "./types";
 
@@ -9,17 +11,13 @@ export type MoveRequestBody = {
 type JsonRecord = Record<string, unknown>;
 
 const BOARD_MIN_INDEX = 0;
-const BOARD_MAX_INDEX = 8;
+const BOARD_MAX_INDEX = BOARD_SIZE - 1;
 const MIN_MAIN_MINUTES = 1;
 const MIN_BYO_SECONDS = 0;
 const BYO_SECONDS_STEP = 10;
-const MIN_PLAYER_NAME_LENGTH = 2;
-const MAX_PLAYER_NAME_LENGTH = 20;
 const MIN_JOIN_TOKEN_LENGTH = 16;
-const MAX_PASSPHRASE_LENGTH = 8;
 const VALID_SEATS = new Set<JoinGameInput["seat"]>(["black", "white"]);
-const DROP_KINDS = new Set(["rook", "bishop", "gold", "silver", "knight", "lance", "pawn"]);
-const PASSPHRASE_PATTERN = /^[A-Za-z0-9]+$/;
+const DROP_KINDS = new Set(HAND_PIECE_KINDS);
 
 function isRecord(input: unknown): input is JsonRecord {
   return !!input && typeof input === "object";
@@ -80,7 +78,7 @@ export function isValidJoinGameInput(input: unknown): input is JoinGameInput {
     return false;
   }
 
-  if (!isValidPlayerName(input.name)) {
+  if (!isValidPlayerNameValue(input.name)) {
     return false;
   }
 
@@ -91,13 +89,8 @@ export function isValidJoinGameInput(input: unknown): input is JoinGameInput {
   return typeof input.joinToken === "string" && input.joinToken.length >= MIN_JOIN_TOKEN_LENGTH;
 }
 
-function isValidPlayerName(name: unknown): boolean {
-  if (typeof name !== "string") {
-    return false;
-  }
-
-  const trimmed = name.trim();
-  return trimmed.length >= MIN_PLAYER_NAME_LENGTH && trimmed.length <= MAX_PLAYER_NAME_LENGTH;
+function isValidPlayerNameValue(name: unknown): boolean {
+  return typeof name === "string" && isValidPlayerName(name);
 }
 
 export function isValidLobbyMatchInput(input: unknown): input is LobbyMatchInput {
@@ -105,7 +98,7 @@ export function isValidLobbyMatchInput(input: unknown): input is LobbyMatchInput
     return false;
   }
 
-  if (!isValidPlayerName(input.name)) {
+  if (!isValidPlayerNameValue(input.name)) {
     return false;
   }
 
@@ -113,8 +106,7 @@ export function isValidLobbyMatchInput(input: unknown): input is LobbyMatchInput
     return false;
   }
 
-  const passphrase = input.passphrase.trim();
-  return passphrase.length > 0 && passphrase.length <= MAX_PASSPHRASE_LENGTH && PASSPHRASE_PATTERN.test(passphrase);
+  return isValidLobbyPassphrase(input.passphrase);
 }
 
 export function isMoveRequestBody(input: unknown): input is MoveRequestBody {


### PR DESCRIPTION
## 概要
- App.tsxの3箇所に重複していたゲーム状態リセット処理を `resetGameRuntimeState` に共通化
- クライアント・サーバー間で重複していたバリデーションロジック (`isValidPlayerName`, `isValidLobbyPassphrase`) を `core/src/lobbyRules.ts` に集約
- 6つのテストファイルに重複していた `readSource` ヘルパーを `app/tests/support/sourceReader.ts` に共通化
- `server/src/validators.ts` のマジックナンバーを `core` の定数 (`BOARD_SIZE`, `HAND_PIECE_KINDS`) に置き換え
- `server/src/types.ts` の import 整理

## テスト計画
- [x] `npm test` — 全138テスト通過
- [x] `npm run build` — ビルド成功
- [ ] 動作確認: オンライン対局のマッチング・観戦・Bot対局が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)