### PR TITLE
fix: 投了処理のcatchブロックにsessionのnullチェックを追加

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1030,7 +1030,7 @@ export function App() {
       applySnapshot(updated, { showDialog: true });
       setNetworkBannerMessage(null);
     } catch (error) {
-      if (error instanceof ApiClientError && error.code === "GAME_ALREADY_FINISHED") {
+      if (error instanceof ApiClientError && error.code === "GAME_ALREADY_FINISHED" && session) {
         await syncSnapshot(session.gameId, { showDialog: false });
       }
       setNetworkBannerFromError(error);


### PR DESCRIPTION
## 概要
- `resign()` の catch ブロック内で `session.gameId` にアクセスする前に `session` の null チェックを追加
- `GAME_ALREADY_FINISHED` エラー時の安全性を確保

## 変更ファイル
- `app/src/App.tsx`

## テスト計画
- [x] `npm test` — 全138テスト通過
- [x] `npm run build` — ビルド成功
- [ ] 動作確認: オンライン対局で投了が正常に動作すること

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)