### PR TITLE
fix: resign()のuseCallback依存配列にsetNetworkBannerFromErrorを追加

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1038,7 +1038,7 @@ export function App() {
     } finally {
       setIsSubmittingResign(false);
     }
-  }, [screenMode, gameOver, isPaused, isSubmittingResign, isSyncingSnapshot, moveHistory.length, matchMode, botSeat, session, state.turn, applySnapshot, syncSnapshot, toGameErrorMessage]);
+  }, [screenMode, gameOver, isPaused, isSubmittingResign, isSyncingSnapshot, moveHistory.length, matchMode, botSeat, session, state.turn, applySnapshot, syncSnapshot, setNetworkBannerFromError, toGameErrorMessage]);
 
   const retrySync = useCallback(async () => {
     if (matchMode !== "online" || !onlineGameId) {


### PR DESCRIPTION
## 概要
- `resign()` の `useCallback` 依存配列に不足していた `setNetworkBannerFromError` を追加
- `react-hooks/exhaustive-deps` ルールへの準拠

## 変更ファイル
- `app/src/App.tsx`

## テスト計画
- [x] `npm test` — 全138テスト通過
- [x] `npm run build` — ビルド成功

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)