### PR TITLE
リファクタリング: デッドコード削除・store.ts分割・App.tsxフック抽出

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -13,8 +13,6 @@ import {
   createClockState,
   DEFAULT_TIME_CONTROL,
   formatClockText,
-  projectClockState,
-  type ClockState,
 } from "./game/timeControl";
 import { canOperateTurn, getTurnLockMessage } from "./game/turnControl";
 import {
@@ -29,17 +27,18 @@ import {
 import { buildResultText, toClockState } from "./online/gameSnapshot";
 import { formatLobbyError, validateMatchLobbyForm, validateSpectateGameForm } from "./online/lobbyValidation";
 import { shouldApplySnapshot } from "./online/pollingPolicy";
-import { computePollingRetryDelayMs, isRetryableNetworkError } from "./online/networkRecovery";
-import { buildGameEventsWebSocketUrl, parseRealtimeSnapshotMessage } from "./online/realtimeEvents";
+import { isRetryableNetworkError } from "./online/networkRecovery";
 import { clearStoredSession, loadStoredSession, saveStoredSession } from "./online/sessionPersistence";
 import { buildSpectatorUrl, parseSpectateGameId } from "./online/spectatorLink";
-import { chooseRandomMove } from "../../bot/src/randomBot";
-import { getBotResignOutcome, isBotTurn } from "./game/botMode";
+import { getBotResignOutcome } from "./game/botMode";
 import { Board } from "./ui/Board";
 import { GameOverDialog } from "./ui/GameOverDialog";
 import { Hand } from "./ui/Hand";
 import { PromotionDialog } from "./ui/PromotionDialog";
 import { SetupScreen } from "./ui/SetupScreen";
+import { useGameClock } from "./hooks/useGameClock";
+import { useGameWebSocket } from "./hooks/useGameWebSocket";
+import { useBotTurn } from "./hooks/useBotTurn";
 
 type PendingPromotion = {
   move: BoardMove;
@@ -92,9 +91,6 @@ export function App() {
   const [spectatorGameId, setSpectatorGameId] = useState<string | null>(null);
 
   const [state, setState] = useState<GameState>(initialState);
-  const [clockState, setClockState] = useState<ClockState>(() => createClockState(initialTimeControl));
-  const [clockTurnStartedAtMs, setClockTurnStartedAtMs] = useState<number>(() => Date.now());
-  const [clockNowMs, setClockNowMs] = useState<number>(() => Date.now());
   const [gameVersion, setGameVersion] = useState<number>(1);
   const [selected, setSelected] = useState<Position | null>(null);
   const [selectedDrop, setSelectedDrop] = useState<PieceKind | null>(null);
@@ -114,6 +110,12 @@ export function App() {
   const pieceSoundRef = useRef<HTMLAudioElement | null>(null);
   const latestVersionRef = useRef(gameVersion);
   const hasAutoStartedSpectateRef = useRef(false);
+
+  const {
+    clockState, setClockState,
+    clockTurnStartedAtMs, setClockTurnStartedAtMs,
+    displayClockState,
+  } = useGameClock(initialTimeControl, { screenMode, matchMode, gameOver, turn: state.turn });
 
   useEffect(() => {
     pieceSoundRef.current = new Audio(PIECE_SOUND_PATH);
@@ -518,123 +520,18 @@ export function App() {
     void startSpectatingByGameId(initialSpectateGameId);
   }, [initialSpectateGameId, startSpectatingByGameId]);
 
-  useEffect(() => {
-    if (
-      typeof window === "undefined"
-      || typeof WebSocket === "undefined"
-      || screenMode !== "game"
-      || matchMode !== "online"
-      || !onlineGameId
-      || gameOver
-      || isOffline
-    ) {
-      return;
-    }
-
-    let disposed = false;
-    let socket: WebSocket | null = null;
-    let reconnectTimerId: number | null = null;
-    let reconnectFailureCount = 0;
-
-    const clearSocket = () => {
-      if (!socket) {
-        return;
-      }
-      socket.onopen = null;
-      socket.onmessage = null;
-      socket.onerror = null;
-      socket.onclose = null;
-      socket.close();
-      socket = null;
-    };
-
-    const clearReconnectTimer = () => {
-      if (reconnectTimerId !== null) {
-        window.clearTimeout(reconnectTimerId);
-        reconnectTimerId = null;
-      }
-    };
-
-    const scheduleReconnect = () => {
-      if (disposed || reconnectTimerId !== null) {
-        return;
-      }
-      const delayMs = computePollingRetryDelayMs(1000, reconnectFailureCount);
-      reconnectFailureCount += 1;
-      reconnectTimerId = window.setTimeout(() => {
-        reconnectTimerId = null;
-        connect();
-      }, delayMs);
-    };
-
-    const connect = () => {
-      if (disposed) {
-        return;
-      }
-      clearSocket();
-      clearReconnectTimer();
-
-      try {
-        const wsUrl = buildGameEventsWebSocketUrl(onlineGameId);
-        socket = new WebSocket(wsUrl);
-      } catch {
-        setNetworkBannerMessage("リアルタイム接続に失敗しました。再接続を試行します。");
-        scheduleReconnect();
-        return;
-      }
-
-      socket.onopen = () => {
-        reconnectFailureCount = 0;
-        setNetworkBannerMessage(null);
-        void syncSnapshot(onlineGameId, {
-          showDialog: false,
-          suppressError: true,
-          onlyIfVersionAdvanced: true,
-          background: true,
-        }).then((synced) => {
-          if (synced) {
-            setGameMessage(null);
-          }
-        });
-      };
-
-      socket.onmessage = (event) => {
-        const snapshot = parseRealtimeSnapshotMessage(event.data);
-        if (!snapshot || snapshot.id !== onlineGameId) {
-          return;
-        }
-        if (!shouldApplySnapshot(latestVersionRef.current, snapshot.version)) {
-          return;
-        }
-        applySnapshot(snapshot, { showDialog: false });
-        setGameMessage(null);
-        setNetworkBannerMessage(null);
-      };
-
-      socket.onerror = () => {
-        if (disposed) {
-          return;
-        }
-        setNetworkBannerMessage("リアルタイム同期が不安定です。再接続を試行します。");
-      };
-
-      socket.onclose = () => {
-        if (disposed) {
-          return;
-        }
-        setNetworkBannerMessage("リアルタイム接続が切断されました。再接続しています。");
-        scheduleReconnect();
-      };
-    };
-
-    connect();
-
-    return () => {
-      disposed = true;
-      clearReconnectTimer();
-      clearSocket();
-    };
-  }, [screenMode, matchMode, onlineGameId, gameOver, isOffline, syncSnapshot, applySnapshot]);
+  useGameWebSocket({
+    screenMode,
+    matchMode,
+    onlineGameId,
+    gameOver,
+    isOffline,
+    syncSnapshot,
+    applySnapshot,
+    latestVersionRef,
+    setNetworkBannerMessage,
+    setGameMessage,
+  });
 
   useEffect(() => {
     if (matchMode !== "online" || typeof window === "undefined") {
@@ -668,23 +565,6 @@ export function App() {
       window.removeEventListener("online", handleOnline);
     };
   }, [matchMode, screenMode, onlineGameId, gameOver, syncSnapshot]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    if (screenMode !== "game" || matchMode !== "online" || gameOver) {
-      return;
-    }
-
-    const timerId = window.setInterval(() => {
-      setClockNowMs(Date.now());
-    }, 250);
-
-    return () => {
-      window.clearInterval(timerId);
-    };
-  }, [screenMode, matchMode, gameOver]);
 
   const checkedKing = useMemo(() => {
     if (!isInCheck(state)) {
@@ -908,64 +788,7 @@ export function App() {
     [pendingPromotion, submitMoveByMode, clearSelections],
   );
 
-  useEffect(() => {
-    if (
-      screenMode !== "game"
-      || matchMode !== "bot"
-      || gameOver
-      || isPaused
-      || pendingPromotion !== null
-      || isSubmittingMove
-      || isSubmittingResign
-      || isSyncingSnapshot
-      || !isBotTurn(botSeat, state.turn)
-    ) {
-      return;
-    }
-
-    const timerId = window.setTimeout(() => {
-      let selectedMove = chooseRandomMove(state);
-      if (selectedMove) {
-        const result = applyMove(state, selectedMove);
-        if (!result.ok) {
-          selectedMove = generateLegalMoves(state).find((candidate) => applyMove(state, candidate).ok) ?? null;
-        }
-      }
-
-      if (!selectedMove) {
-        resolveBotMatchOutcome(state);
-        return;
-      }
-
-      const applied = applyMove(state, selectedMove);
-      if (!applied.ok) {
-        setGameMessage("\u30dc\u30c3\u30c8\u306e\u7740\u624b\u751f\u6210\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002");
-        return;
-      }
-
-      appendMoveHistory(selectedMove);
-      playPieceSound();
-      setState(applied.value);
-      setGameVersion((current) => {
-        const next = current + 1;
-        latestVersionRef.current = next;
-        return next;
-      });
-      setGameMessage(null);
-
-      const ended = resolveBotMatchOutcome(applied.value);
-      if (!ended) {
-        setGameOver(false);
-        setShowRestartDialog(false);
-        setWinner(null);
-        setResultText(null);
-      }
-    }, 350);
-
-    return () => {
-      window.clearTimeout(timerId);
-    };
-  }, [
+  useBotTurn({
     screenMode,
     matchMode,
     gameOver,
@@ -979,7 +802,15 @@ export function App() {
     appendMoveHistory,
     playPieceSound,
     resolveBotMatchOutcome,
-  ]);
+    setState,
+    setGameVersion,
+    setGameMessage,
+    setGameOver,
+    setShowRestartDialog,
+    setWinner,
+    setResultText,
+    latestVersionRef,
+  });
 
   const returnToSetup = useCallback(() => {
     setScreenMode("setup");
@@ -1102,14 +933,6 @@ export function App() {
         : isSpectatorMode
           ? `観戦中: ${winnerLabel(state.turn)}の手番`
           : `手番: ${winnerLabel(state.turn)}`;
-
-  const displayClockState = useMemo(() => {
-    if (screenMode !== "game" || matchMode !== "online" || gameOver) {
-      return clockState;
-    }
-
-    return projectClockState(clockState, state.turn, clockTurnStartedAtMs, clockNowMs);
-  }, [screenMode, matchMode, gameOver, clockState, state.turn, clockTurnStartedAtMs, clockNowMs]);
 
   const boardPerspective: Color = playerSeat === "white" ? "white" : "black";
   const topSideColor: Color = boardPerspective === "white" ? "black" : "white";

--- a/app/src/game/position.ts
+++ b/app/src/game/position.ts
@@ -24,6 +24,3 @@ export function toBoardPosition(displayPosition: Position, perspective: Color): 
   };
 }
 
-export function toDisplayPosition(boardPosition: Position, perspective: Color): Position {
-  return toBoardPosition(boardPosition, perspective);
-}

--- a/app/src/game/timeControl.ts
+++ b/app/src/game/timeControl.ts
@@ -12,14 +12,6 @@ export type ClockState = {
 
 export const DEFAULT_TIME_CONTROL: TimeControl = { mainSeconds: 600, byoSeconds: 30 };
 
-function clampToNonNegativeInteger(value: number): number {
-  return Math.max(0, Math.floor(value));
-}
-
-function toTenSecondStep(value: number): number {
-  return Math.floor(value / 10) * 10;
-}
-
 export function createClockState(control: TimeControl): ClockState {
   return {
     main: { black: control.mainSeconds, white: control.mainSeconds },
@@ -27,7 +19,7 @@ export function createClockState(control: TimeControl): ClockState {
   };
 }
 
-export function formatSeconds(seconds: number): string {
+function formatSeconds(seconds: number): string {
   const s = Math.max(0, seconds);
   const min = Math.floor(s / 60);
   const sec = s % 60;
@@ -66,9 +58,3 @@ export function projectClockState(base: ClockState, turn: Color, turnStartedAtMs
   return projected;
 }
 
-export function normalizeTimeControl(mainMinutes: number, byoSeconds: number): TimeControl {
-  return {
-    mainSeconds: clampToNonNegativeInteger(mainMinutes) * 60,
-    byoSeconds: toTenSecondStep(clampToNonNegativeInteger(byoSeconds)),
-  };
-}

--- a/app/src/hooks/useBotTurn.ts
+++ b/app/src/hooks/useBotTurn.ts
@@ -1,0 +1,137 @@
+import { useEffect } from "react";
+import { applyMove } from "../../../core/src/applyMove";
+import { generateLegalMoves } from "../../../core/src/moveGenerator";
+import type { Color, GameState, Move } from "../../../core/src/types";
+import { chooseRandomMove } from "../../../bot/src/randomBot";
+import { isBotTurn } from "../game/botMode";
+
+type UseBotTurnParams = {
+  screenMode: "setup" | "game";
+  matchMode: "online" | "bot";
+  gameOver: boolean;
+  isPaused: boolean;
+  pendingPromotion: unknown | null;
+  isSubmittingMove: boolean;
+  isSubmittingResign: boolean;
+  isSyncingSnapshot: boolean;
+  botSeat: Color;
+  state: GameState;
+  appendMoveHistory: (move: Move) => void;
+  playPieceSound: () => void;
+  resolveBotMatchOutcome: (state: GameState) => boolean;
+  setState: (state: GameState) => void;
+  setGameVersion: (updater: (current: number) => number) => void;
+  setGameMessage: (message: string | null) => void;
+  setGameOver: (gameOver: boolean) => void;
+  setShowRestartDialog: (show: boolean) => void;
+  setWinner: (winner: Color | null) => void;
+  setResultText: (text: string | null) => void;
+  latestVersionRef: React.MutableRefObject<number>;
+};
+
+export function useBotTurn(params: UseBotTurnParams): void {
+  const {
+    screenMode,
+    matchMode,
+    gameOver,
+    isPaused,
+    pendingPromotion,
+    isSubmittingMove,
+    isSubmittingResign,
+    isSyncingSnapshot,
+    botSeat,
+    state,
+    appendMoveHistory,
+    playPieceSound,
+    resolveBotMatchOutcome,
+    setState,
+    setGameVersion,
+    setGameMessage,
+    setGameOver,
+    setShowRestartDialog,
+    setWinner,
+    setResultText,
+    latestVersionRef,
+  } = params;
+
+  useEffect(() => {
+    if (
+      screenMode !== "game"
+      || matchMode !== "bot"
+      || gameOver
+      || isPaused
+      || pendingPromotion !== null
+      || isSubmittingMove
+      || isSubmittingResign
+      || isSyncingSnapshot
+      || !isBotTurn(botSeat, state.turn)
+    ) {
+      return;
+    }
+
+    const timerId = window.setTimeout(() => {
+      let selectedMove = chooseRandomMove(state);
+      if (selectedMove) {
+        const result = applyMove(state, selectedMove);
+        if (!result.ok) {
+          selectedMove = generateLegalMoves(state).find((candidate) => applyMove(state, candidate).ok) ?? null;
+        }
+      }
+
+      if (!selectedMove) {
+        resolveBotMatchOutcome(state);
+        return;
+      }
+
+      const applied = applyMove(state, selectedMove);
+      if (!applied.ok) {
+        setGameMessage("ボットの着手生成に失敗しました。");
+        return;
+      }
+
+      appendMoveHistory(selectedMove);
+      playPieceSound();
+      setState(applied.value);
+      setGameVersion((current) => {
+        const next = current + 1;
+        latestVersionRef.current = next;
+        return next;
+      });
+      setGameMessage(null);
+
+      const ended = resolveBotMatchOutcome(applied.value);
+      if (!ended) {
+        setGameOver(false);
+        setShowRestartDialog(false);
+        setWinner(null);
+        setResultText(null);
+      }
+    }, 350);
+
+    return () => {
+      window.clearTimeout(timerId);
+    };
+  }, [
+    screenMode,
+    matchMode,
+    gameOver,
+    isPaused,
+    pendingPromotion,
+    isSubmittingMove,
+    isSubmittingResign,
+    isSyncingSnapshot,
+    botSeat,
+    state,
+    appendMoveHistory,
+    playPieceSound,
+    resolveBotMatchOutcome,
+    setState,
+    setGameVersion,
+    setGameMessage,
+    setGameOver,
+    setShowRestartDialog,
+    setWinner,
+    setResultText,
+    latestVersionRef,
+  ]);
+}

--- a/app/src/hooks/useGameClock.ts
+++ b/app/src/hooks/useGameClock.ts
@@ -1,0 +1,56 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  createClockState,
+  projectClockState,
+  type ClockState,
+  type TimeControl,
+} from "../game/timeControl";
+import type { Color } from "../../../core/src/types";
+
+type UseGameClockParams = {
+  screenMode: "setup" | "game";
+  matchMode: "online" | "bot";
+  gameOver: boolean;
+  turn: Color;
+};
+
+export function useGameClock(initialTimeControl: TimeControl, params: UseGameClockParams) {
+  const { screenMode, matchMode, gameOver, turn } = params;
+
+  const [clockState, setClockState] = useState<ClockState>(() => createClockState(initialTimeControl));
+  const [clockTurnStartedAtMs, setClockTurnStartedAtMs] = useState<number>(() => Date.now());
+  const [clockNowMs, setClockNowMs] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (screenMode !== "game" || matchMode !== "online" || gameOver) {
+      return;
+    }
+
+    const timerId = window.setInterval(() => {
+      setClockNowMs(Date.now());
+    }, 250);
+
+    return () => {
+      window.clearInterval(timerId);
+    };
+  }, [screenMode, matchMode, gameOver]);
+
+  const displayClockState = useMemo(() => {
+    if (screenMode !== "game" || matchMode !== "online" || gameOver) {
+      return clockState;
+    }
+
+    return projectClockState(clockState, turn, clockTurnStartedAtMs, clockNowMs);
+  }, [screenMode, matchMode, gameOver, clockState, turn, clockTurnStartedAtMs, clockNowMs]);
+
+  return {
+    clockState,
+    setClockState,
+    clockTurnStartedAtMs,
+    setClockTurnStartedAtMs,
+    displayClockState,
+  };
+}

--- a/app/src/hooks/useGameWebSocket.ts
+++ b/app/src/hooks/useGameWebSocket.ts
@@ -1,0 +1,158 @@
+import { useEffect } from "react";
+import { shouldApplySnapshot } from "../online/pollingPolicy";
+import { computePollingRetryDelayMs } from "../online/networkRecovery";
+import { buildGameEventsWebSocketUrl, parseRealtimeSnapshotMessage } from "../online/realtimeEvents";
+import type { GameSnapshot } from "../online/gameApi";
+
+type SyncSnapshotFn = (
+  gameId: string,
+  options: { showDialog: boolean; suppressError: boolean; onlyIfVersionAdvanced?: boolean; background?: boolean },
+) => Promise<boolean>;
+
+type ApplySnapshotFn = (snapshot: GameSnapshot, options: { showDialog: boolean }) => void;
+
+type UseGameWebSocketParams = {
+  screenMode: "setup" | "game";
+  matchMode: "online" | "bot";
+  onlineGameId: string | null;
+  gameOver: boolean;
+  isOffline: boolean;
+  syncSnapshot: SyncSnapshotFn;
+  applySnapshot: ApplySnapshotFn;
+  latestVersionRef: React.RefObject<number>;
+  setNetworkBannerMessage: (message: string | null) => void;
+  setGameMessage: (message: string | null) => void;
+};
+
+export function useGameWebSocket(params: UseGameWebSocketParams): void {
+  const {
+    screenMode,
+    matchMode,
+    onlineGameId,
+    gameOver,
+    isOffline,
+    syncSnapshot,
+    applySnapshot,
+    latestVersionRef,
+    setNetworkBannerMessage,
+    setGameMessage,
+  } = params;
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined"
+      || typeof WebSocket === "undefined"
+      || screenMode !== "game"
+      || matchMode !== "online"
+      || !onlineGameId
+      || gameOver
+      || isOffline
+    ) {
+      return;
+    }
+
+    let disposed = false;
+    let socket: WebSocket | null = null;
+    let reconnectTimerId: number | null = null;
+    let reconnectFailureCount = 0;
+
+    const clearSocket = () => {
+      if (!socket) {
+        return;
+      }
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onerror = null;
+      socket.onclose = null;
+      socket.close();
+      socket = null;
+    };
+
+    const clearReconnectTimer = () => {
+      if (reconnectTimerId !== null) {
+        window.clearTimeout(reconnectTimerId);
+        reconnectTimerId = null;
+      }
+    };
+
+    const scheduleReconnect = () => {
+      if (disposed || reconnectTimerId !== null) {
+        return;
+      }
+      const delayMs = computePollingRetryDelayMs(1000, reconnectFailureCount);
+      reconnectFailureCount += 1;
+      reconnectTimerId = window.setTimeout(() => {
+        reconnectTimerId = null;
+        connect();
+      }, delayMs);
+    };
+
+    const connect = () => {
+      if (disposed) {
+        return;
+      }
+      clearSocket();
+      clearReconnectTimer();
+
+      try {
+        const wsUrl = buildGameEventsWebSocketUrl(onlineGameId);
+        socket = new WebSocket(wsUrl);
+      } catch {
+        setNetworkBannerMessage("リアルタイム接続に失敗しました。再接続を試行します。");
+        scheduleReconnect();
+        return;
+      }
+
+      socket.onopen = () => {
+        reconnectFailureCount = 0;
+        setNetworkBannerMessage(null);
+        void syncSnapshot(onlineGameId, {
+          showDialog: false,
+          suppressError: true,
+          onlyIfVersionAdvanced: true,
+          background: true,
+        }).then((synced) => {
+          if (synced) {
+            setGameMessage(null);
+          }
+        });
+      };
+
+      socket.onmessage = (event) => {
+        const snapshot = parseRealtimeSnapshotMessage(event.data);
+        if (!snapshot || snapshot.id !== onlineGameId) {
+          return;
+        }
+        if (!shouldApplySnapshot(latestVersionRef.current, snapshot.version)) {
+          return;
+        }
+        applySnapshot(snapshot, { showDialog: false });
+        setGameMessage(null);
+        setNetworkBannerMessage(null);
+      };
+
+      socket.onerror = () => {
+        if (disposed) {
+          return;
+        }
+        setNetworkBannerMessage("リアルタイム同期が不安定です。再接続を試行します。");
+      };
+
+      socket.onclose = () => {
+        if (disposed) {
+          return;
+        }
+        setNetworkBannerMessage("リアルタイム接続が切断されました。再接続しています。");
+        scheduleReconnect();
+      };
+    };
+
+    connect();
+
+    return () => {
+      disposed = true;
+      clearReconnectTimer();
+      clearSocket();
+    };
+  }, [screenMode, matchMode, onlineGameId, gameOver, isOffline, syncSnapshot, applySnapshot, latestVersionRef, setNetworkBannerMessage, setGameMessage]);
+}

--- a/app/src/online/lobbyValidation.ts
+++ b/app/src/online/lobbyValidation.ts
@@ -2,18 +2,6 @@ import { isValidLobbyPassphrase, isValidPlayerName } from "../../../core/src/lob
 
 type Seat = "black" | "white";
 
-export type CreateGameFormInput = {
-  mainMinutes: string;
-  byoSeconds: string;
-};
-
-export type JoinGameFormInput = {
-  gameId: string;
-  joinToken: string;
-  name: string;
-  seat: Seat;
-};
-
 export type MatchLobbyFormInput = {
   passphrase: string;
   name: string;
@@ -34,72 +22,6 @@ type ValidationError = {
 };
 
 export type ValidationResult<T> = ValidationOk<T> | ValidationError;
-
-function toInteger(value: string): number | null {
-  if (!/^\d+$/.test(value.trim())) {
-    return null;
-  }
-  const parsed = Number.parseInt(value, 10);
-  return Number.isInteger(parsed) ? parsed : null;
-}
-
-export function validateCreateGameForm(input: CreateGameFormInput): ValidationResult<{ mainMinutes: number; byoSeconds: number }> {
-  const errors: string[] = [];
-  const mainMinutes = toInteger(input.mainMinutes);
-  const byoSeconds = toInteger(input.byoSeconds);
-
-  if (mainMinutes === null || mainMinutes < 1) {
-    errors.push("持ち時間は1分以上の整数で入力してください。");
-  }
-  if (byoSeconds === null || byoSeconds < 0 || byoSeconds % 10 !== 0) {
-    errors.push("秒読みは0以上かつ10秒単位で入力してください。");
-  }
-
-  if (errors.length > 0) {
-    return { ok: false, errors };
-  }
-
-  return {
-    ok: true,
-    value: {
-      mainMinutes,
-      byoSeconds,
-    },
-  };
-}
-
-export function validateJoinGameForm(
-  input: JoinGameFormInput,
-): ValidationResult<{ gameId: string; joinToken: string; name: string; seat: Seat }> {
-  const errors: string[] = [];
-  const gameId = input.gameId.trim();
-  const joinToken = input.joinToken.trim();
-  const name = input.name.trim();
-
-  if (!gameId) {
-    errors.push("gameIdを入力してください。");
-  }
-  if (!joinToken) {
-    errors.push("joinTokenを入力してください。");
-  }
-  if (!isValidPlayerName(name)) {
-    errors.push("表示名は2〜20文字で入力してください。");
-  }
-
-  if (errors.length > 0) {
-    return { ok: false, errors };
-  }
-
-  return {
-    ok: true,
-    value: {
-      gameId,
-      joinToken,
-      name,
-      seat: input.seat,
-    },
-  };
-}
 
 export function validateMatchLobbyForm(input: MatchLobbyFormInput): ValidationResult<{ passphrase: string; name: string }> {
   const errors: string[] = [];

--- a/app/src/online/pollingPolicy.ts
+++ b/app/src/online/pollingPolicy.ts
@@ -1,10 +1,3 @@
-const VISIBLE_POLLING_MS = 2000;
-const HIDDEN_POLLING_MS = 3000;
-
-export function getPollingIntervalMs(isDocumentHidden: boolean): number {
-  return isDocumentHidden ? HIDDEN_POLLING_MS : VISIBLE_POLLING_MS;
-}
-
 export function shouldApplySnapshot(currentVersion: number, nextVersion: number): boolean {
   return nextVersion > currentVersion;
 }

--- a/app/tests/onlineLobby.test.ts
+++ b/app/tests/onlineLobby.test.ts
@@ -1,28 +1,7 @@
 import { describe, expect, test } from "vitest";
-import { formatLobbyError, validateCreateGameForm, validateMatchLobbyForm, validateSpectateGameForm } from "../src/online/lobbyValidation";
+import { formatLobbyError, validateMatchLobbyForm, validateSpectateGameForm } from "../src/online/lobbyValidation";
 
 describe("lobby validation", () => {
-  test("validateCreateGameForm returns errors for invalid values", () => {
-    const result = validateCreateGameForm({ mainMinutes: "0", byoSeconds: "7" });
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      return;
-    }
-    expect(result.errors).toContain("持ち時間は1分以上の整数で入力してください。");
-    expect(result.errors).toContain("秒読みは0以上かつ10秒単位で入力してください。");
-  });
-
-  test("validateCreateGameForm normalizes valid values", () => {
-    const result = validateCreateGameForm({ mainMinutes: "15", byoSeconds: "30" });
-    expect(result).toEqual({
-      ok: true,
-      value: {
-        mainMinutes: 15,
-        byoSeconds: 30,
-      },
-    });
-  });
-
   test("validateMatchLobbyForm returns errors when required fields are invalid", () => {
     const result = validateMatchLobbyForm({
       passphrase: "",

--- a/app/tests/pollingPolicy.test.ts
+++ b/app/tests/pollingPolicy.test.ts
@@ -1,15 +1,7 @@
 import { describe, expect, test } from "vitest";
-import { getPollingIntervalMs, shouldApplySnapshot } from "../src/online/pollingPolicy";
+import { shouldApplySnapshot } from "../src/online/pollingPolicy";
 
 describe("polling policy", () => {
-  test("uses 2 seconds when page is visible", () => {
-    expect(getPollingIntervalMs(false)).toBe(2000);
-  });
-
-  test("uses 3 seconds when page is hidden", () => {
-    expect(getPollingIntervalMs(true)).toBe(3000);
-  });
-
   test("applies snapshot only when version increases", () => {
     expect(shouldApplySnapshot(3, 3)).toBe(false);
     expect(shouldApplySnapshot(4, 3)).toBe(false);

--- a/app/tests/position.test.ts
+++ b/app/tests/position.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { isSamePosition, positionToKey, toBoardPosition, toDisplayPosition } from "../src/game/position";
+import { isSamePosition, positionToKey, toBoardPosition } from "../src/game/position";
 
 describe("position helpers", () => {
   test("positionToKey creates stable coordinate key", () => {
@@ -16,11 +16,9 @@ describe("position helpers", () => {
   test("keeps coordinates as-is for black perspective", () => {
     const position = { x: 2, y: 6 };
     expect(toBoardPosition(position, "black")).toEqual(position);
-    expect(toDisplayPosition(position, "black")).toEqual(position);
   });
 
   test("mirrors coordinates for white perspective", () => {
     expect(toBoardPosition({ x: 0, y: 0 }, "white")).toEqual({ x: 8, y: 8 });
-    expect(toDisplayPosition({ x: 8, y: 8 }, "white")).toEqual({ x: 0, y: 0 });
   });
 });

--- a/app/tests/timeControl.test.ts
+++ b/app/tests/timeControl.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { formatClockText, normalizeTimeControl, projectClockState } from "../src/game/timeControl";
+import { formatClockText, projectClockState } from "../src/game/timeControl";
 
 describe("timeControl helpers", () => {
-  it("normalizes user input by minute and 10-second units", () => {
-    expect(normalizeTimeControl(5.8, 37)).toEqual({ mainSeconds: 300, byoSeconds: 30 });
-    expect(normalizeTimeControl(-2, -1)).toEqual({ mainSeconds: 0, byoSeconds: 0 });
-  });
-
   it("switches display to byo-yomi after main time reaches zero", () => {
     expect(formatClockText(125, 30)).toBe("02:05");
     expect(formatClockText(0, 30)).toBe("秒読み 00:30");

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -1,7 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { readFile, readdir } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { Pool } from "pg";
 import type { Move, GameState } from "../../core/src/types";
 import { applyMove } from "../../core/src/applyMove";
@@ -9,82 +6,15 @@ import { createInitialGameState } from "../../core/src/initialPosition";
 import { createSessionToken, hashToken } from "./auth";
 import { issueManagedAuthToken } from "./managedAuth";
 import type { CreateGameInput, Game, JoinGameInput, LobbyMatchInput, LobbyMatchResult, MoveRecord, Player, Seat } from "./types";
+import type { GameRow, LastPlyRow, MoveRow, PersistedGame, PlayerRow, PoolLike, TransactionClient } from "./storeTypes";
+import { toIsoNow, toNumber } from "./storeDbUtils";
+import { splitSqlStatements } from "./storeDbUtils";
+import { createJoinToken, oppositeSeat, pickLobbySeat } from "./storeSeatLogic";
+import { consumeElapsedClock, settleTimeoutIfNeeded } from "./storeClockLogic";
+import { toGame, toPersistedGame, toProjectedGame, mapGameRow, mapPlayerRow, mapMoveRow } from "./storeGameTransforms";
+import { getMigrationScripts } from "./storeMigrations";
 
-type DbQueryResult<T> = {
-  rows: T[];
-  rowCount: number | null;
-};
-
-type Queryable = {
-  query<T extends Record<string, unknown>>(text: string, params?: readonly unknown[]): Promise<DbQueryResult<T>>;
-};
-
-type TransactionClient = Queryable & {
-  release: () => void;
-};
-
-type PoolLike = Queryable & {
-  connect: () => Promise<TransactionClient>;
-  end?: () => Promise<void>;
-};
-
-type PersistedGame = {
-  id: string;
-  status: Game["status"];
-  turn: Seat;
-  state: GameState;
-  mainSecondsBlack: number;
-  mainSecondsWhite: number;
-  byoSecondsBlack: number;
-  byoSecondsWhite: number;
-  resultType: Game["resultType"] | null;
-  winner: Seat | null;
-  version: number;
-  turnStartedAtMs: number;
-  createdAt: string;
-  updatedAt: string;
-  joinTokenHash: string;
-};
-
-type GameRow = {
-  id: string;
-  status: Game["status"];
-  turn: Seat;
-  state_json: GameState;
-  main_seconds_black: number | string;
-  main_seconds_white: number | string;
-  byo_seconds_black: number | string;
-  byo_seconds_white: number | string;
-  result_type: Game["resultType"] | null;
-  winner: Seat | null;
-  version: number | string;
-  turn_started_at_ms: number | string | null;
-  created_at: string | Date;
-  updated_at: string | Date;
-  join_token_hash: string;
-};
-
-type PlayerRow = {
-  id: string;
-  game_id: string;
-  seat: Seat;
-  guest_id: string;
-  display_name: string;
-  session_token_hash: string;
-  joined_at: string | Date;
-};
-
-type MoveRow = {
-  ply: number | string;
-  actor_seat: Seat;
-  move_json: Move;
-  state_json_after: GameState;
-  created_at: string | Date;
-};
-
-type LastPlyRow = {
-  ply: number | string;
-};
+export type { PoolLike } from "./storeTypes";
 
 export interface GameStore {
   createGame(input: CreateGameInput): Promise<{ gameId: string; joinToken: string }>;
@@ -106,331 +36,6 @@ export interface GameStore {
 
 const DEFAULT_MATCH_MAIN_MINUTES = 10;
 const DEFAULT_MATCH_BYO_SECONDS = 30;
-
-function toIsoNow(): string {
-  return new Date().toISOString();
-}
-
-function toIso(value: string | Date): string {
-  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
-}
-
-function toNumber(value: number | string | bigint | null | undefined): number {
-  if (typeof value === "number") {
-    return value;
-  }
-  if (typeof value === "bigint") {
-    return Number(value);
-  }
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : 0;
-  }
-  return 0;
-}
-
-function splitSqlStatements(script: string): string[] {
-  return script
-    .split(/;\s*(?:\r?\n|$)/g)
-    .map((statement) => statement.trim())
-    .filter((statement) => statement.length > 0);
-}
-
-function createJoinToken(): string {
-  return randomUUID().replaceAll("-", "");
-}
-
-function pickAvailableSeat(seats: readonly Seat[]): Seat | null {
-  if (!seats.includes("black")) {
-    return "black";
-  }
-  if (!seats.includes("white")) {
-    return "white";
-  }
-  return null;
-}
-
-function pickRandomSeat(): Seat {
-  return Math.random() < 0.5 ? "black" : "white";
-}
-
-function pickLobbySeat(seats: readonly Seat[]): Seat | null {
-  if (seats.length === 0) {
-    return pickRandomSeat();
-  }
-  return pickAvailableSeat(seats);
-}
-
-function oppositeSeat(seat: Seat): Seat {
-  return seat === "black" ? "white" : "black";
-}
-
-type TurnClockProjection = {
-  remainingMainSeconds: number;
-  remainingByoSeconds: number;
-  timedOut: boolean;
-};
-
-type SnapshotClockProjection = {
-  mainSecondsBlack: number;
-  mainSecondsWhite: number;
-  byoSecondsBlack: number;
-  byoSecondsWhite: number;
-  turnStartedAtMs: number;
-  timedOut: boolean;
-};
-
-function getElapsedWholeSeconds(turnStartedAtMs: number, nowMs: number): number {
-  return Math.floor(Math.max(0, nowMs - turnStartedAtMs) / 1000);
-}
-
-function projectTurnClock(mainSeconds: number, byoSeconds: number, elapsedSeconds: number): TurnClockProjection {
-  if (elapsedSeconds <= 0) {
-    return {
-      remainingMainSeconds: mainSeconds,
-      remainingByoSeconds: byoSeconds,
-      timedOut: false,
-    };
-  }
-
-  if (elapsedSeconds <= mainSeconds) {
-    return {
-      remainingMainSeconds: mainSeconds - elapsedSeconds,
-      remainingByoSeconds: byoSeconds,
-      timedOut: false,
-    };
-  }
-
-  const overtime = elapsedSeconds - mainSeconds;
-  return {
-    remainingMainSeconds: 0,
-    remainingByoSeconds: Math.max(0, byoSeconds - overtime),
-    timedOut: overtime > byoSeconds,
-  };
-}
-
-function projectClockForSnapshot(game: PersistedGame, nowMs: number): SnapshotClockProjection {
-  const base: SnapshotClockProjection = {
-    mainSecondsBlack: game.mainSecondsBlack,
-    mainSecondsWhite: game.mainSecondsWhite,
-    byoSecondsBlack: game.byoSecondsBlack,
-    byoSecondsWhite: game.byoSecondsWhite,
-    turnStartedAtMs: game.turnStartedAtMs,
-    timedOut: false,
-  };
-
-  if (game.status !== "active") {
-    return base;
-  }
-
-  const elapsedSeconds = getElapsedWholeSeconds(game.turnStartedAtMs, nowMs);
-  if (elapsedSeconds <= 0) {
-    return base;
-  }
-
-  if (game.turn === "black") {
-    const projected = projectTurnClock(game.mainSecondsBlack, game.byoSecondsBlack, elapsedSeconds);
-    return {
-      ...base,
-      mainSecondsBlack: projected.remainingMainSeconds,
-      byoSecondsBlack: projected.remainingByoSeconds,
-      turnStartedAtMs: game.turnStartedAtMs + elapsedSeconds * 1000,
-      timedOut: projected.timedOut,
-    };
-  }
-
-  const projected = projectTurnClock(game.mainSecondsWhite, game.byoSecondsWhite, elapsedSeconds);
-  return {
-    ...base,
-    mainSecondsWhite: projected.remainingMainSeconds,
-    byoSecondsWhite: projected.remainingByoSeconds,
-    turnStartedAtMs: game.turnStartedAtMs + elapsedSeconds * 1000,
-    timedOut: projected.timedOut,
-  };
-}
-
-function consumeElapsedClock(game: PersistedGame, nowMs: number): boolean {
-  if (game.status !== "active") {
-    return false;
-  }
-
-  const elapsedSeconds = getElapsedWholeSeconds(game.turnStartedAtMs, nowMs);
-  if (elapsedSeconds <= 0) {
-    return false;
-  }
-
-  if (game.turn === "black") {
-    const projected = projectTurnClock(game.mainSecondsBlack, game.byoSecondsBlack, elapsedSeconds);
-    game.mainSecondsBlack = projected.remainingMainSeconds;
-    game.turnStartedAtMs += elapsedSeconds * 1000;
-    if (!projected.timedOut) {
-      return false;
-    }
-  } else {
-    const projected = projectTurnClock(game.mainSecondsWhite, game.byoSecondsWhite, elapsedSeconds);
-    game.mainSecondsWhite = projected.remainingMainSeconds;
-    game.turnStartedAtMs += elapsedSeconds * 1000;
-    if (!projected.timedOut) {
-      return false;
-    }
-  }
-
-  game.status = "finished";
-  game.resultType = "timeout";
-  game.winner = oppositeSeat(game.turn);
-  game.updatedAt = new Date(nowMs).toISOString();
-  game.version += 1;
-  return true;
-}
-
-function settleTimeoutIfNeeded(game: PersistedGame, nowMs: number): boolean {
-  const projected = projectClockForSnapshot(game, nowMs);
-  if (!projected.timedOut) {
-    return false;
-  }
-
-  game.mainSecondsBlack = projected.mainSecondsBlack;
-  game.mainSecondsWhite = projected.mainSecondsWhite;
-  game.turnStartedAtMs = projected.turnStartedAtMs;
-  game.status = "finished";
-  game.resultType = "timeout";
-  game.winner = oppositeSeat(game.turn);
-  game.updatedAt = new Date(nowMs).toISOString();
-  game.version += 1;
-  return true;
-}
-
-function toGame(snapshot: PersistedGame): Game {
-  return {
-    id: snapshot.id,
-    status: snapshot.status,
-    turn: snapshot.turn,
-    state: snapshot.state,
-    mainSecondsBlack: snapshot.mainSecondsBlack,
-    mainSecondsWhite: snapshot.mainSecondsWhite,
-    byoSecondsBlack: snapshot.byoSecondsBlack,
-    byoSecondsWhite: snapshot.byoSecondsWhite,
-    resultType: snapshot.resultType,
-    winner: snapshot.winner,
-    version: snapshot.version,
-    turnStartedAtMs: snapshot.turnStartedAtMs,
-    createdAt: snapshot.createdAt,
-    updatedAt: snapshot.updatedAt,
-  };
-}
-
-function toPersistedGame(game: Game, joinTokenHash = ""): PersistedGame {
-  return {
-    id: game.id,
-    status: game.status,
-    turn: game.turn,
-    state: game.state,
-    mainSecondsBlack: game.mainSecondsBlack,
-    mainSecondsWhite: game.mainSecondsWhite,
-    byoSecondsBlack: game.byoSecondsBlack,
-    byoSecondsWhite: game.byoSecondsWhite,
-    resultType: game.resultType,
-    winner: game.winner,
-    version: game.version,
-    turnStartedAtMs: game.turnStartedAtMs,
-    createdAt: game.createdAt,
-    updatedAt: game.updatedAt,
-    joinTokenHash,
-  };
-}
-
-function toProjectedGame(snapshot: PersistedGame, nowMs: number): Game {
-  if (snapshot.status !== "active") {
-    return toGame(snapshot);
-  }
-
-  const projected = projectClockForSnapshot(snapshot, nowMs);
-  if (projected.timedOut) {
-    return {
-      ...toGame(snapshot),
-      mainSecondsBlack: projected.mainSecondsBlack,
-      mainSecondsWhite: projected.mainSecondsWhite,
-      byoSecondsBlack: projected.byoSecondsBlack,
-      byoSecondsWhite: projected.byoSecondsWhite,
-      turnStartedAtMs: projected.turnStartedAtMs,
-      status: "finished",
-      resultType: "timeout",
-      winner: oppositeSeat(snapshot.turn),
-      version: snapshot.version + 1,
-      updatedAt: new Date(nowMs).toISOString(),
-    };
-  }
-
-  return {
-    ...toGame(snapshot),
-    mainSecondsBlack: projected.mainSecondsBlack,
-    mainSecondsWhite: projected.mainSecondsWhite,
-    byoSecondsBlack: projected.byoSecondsBlack,
-    byoSecondsWhite: projected.byoSecondsWhite,
-    turnStartedAtMs: projected.turnStartedAtMs,
-  };
-}
-
-function mapGameRow(row: GameRow): PersistedGame {
-  const updatedAt = toIso(row.updated_at);
-  const persistedTurnStartedAtMs = toNumber(row.turn_started_at_ms);
-  const fallbackTurnStartedAtMs = new Date(updatedAt).getTime();
-
-  return {
-    id: row.id,
-    status: row.status,
-    turn: row.turn,
-    state: row.state_json,
-    mainSecondsBlack: toNumber(row.main_seconds_black),
-    mainSecondsWhite: toNumber(row.main_seconds_white),
-    byoSecondsBlack: toNumber(row.byo_seconds_black),
-    byoSecondsWhite: toNumber(row.byo_seconds_white),
-    resultType: row.result_type,
-    winner: row.winner,
-    version: toNumber(row.version),
-    turnStartedAtMs: persistedTurnStartedAtMs > 0 ? persistedTurnStartedAtMs : fallbackTurnStartedAtMs,
-    createdAt: toIso(row.created_at),
-    updatedAt,
-    joinTokenHash: row.join_token_hash,
-  };
-}
-
-function mapPlayerRow(row: PlayerRow): Player {
-  return {
-    id: row.id,
-    gameId: row.game_id,
-    seat: row.seat,
-    guestId: row.guest_id,
-    displayName: row.display_name,
-    sessionTokenHash: row.session_token_hash,
-    joinedAt: toIso(row.joined_at),
-  };
-}
-
-function mapMoveRow(row: MoveRow): MoveRecord {
-  return {
-    ply: toNumber(row.ply),
-    actorSeat: row.actor_seat,
-    move: row.move_json,
-    stateAfter: row.state_json_after,
-    createdAt: toIso(row.created_at),
-  };
-}
-
-let migrationScriptsPromise: Promise<string[]> | null = null;
-
-async function loadMigrationScripts(): Promise<string[]> {
-  const migrationDir = fileURLToPath(new URL("../db/migrations", import.meta.url));
-  const files = (await readdir(migrationDir)).filter((file) => file.endsWith(".sql")).sort();
-  return Promise.all(files.map((file) => readFile(path.join(migrationDir, file), "utf8")));
-}
-
-async function getMigrationScripts(): Promise<string[]> {
-  if (!migrationScriptsPromise) {
-    migrationScriptsPromise = loadMigrationScripts();
-  }
-  return migrationScriptsPromise;
-}
 
 export class InMemoryStore implements GameStore {
   private readonly games = new Map<string, Game>();
@@ -765,7 +370,7 @@ export class PostgresStore implements GameStore {
     }
   }
 
-  private async lockGame(client: Queryable, gameId: string): Promise<PersistedGame | null> {
+  private async lockGame(client: TransactionClient, gameId: string): Promise<PersistedGame | null> {
     const result = await client.query<GameRow>(
       `SELECT
          id,
@@ -796,7 +401,7 @@ export class PostgresStore implements GameStore {
     return mapGameRow(result.rows[0]);
   }
 
-  private async lockWaitingGameByPassphrase(client: Queryable, passphraseHash: string): Promise<PersistedGame | null> {
+  private async lockWaitingGameByPassphrase(client: TransactionClient, passphraseHash: string): Promise<PersistedGame | null> {
     const result = await client.query<GameRow>(
       `SELECT
          id,
@@ -829,7 +434,7 @@ export class PostgresStore implements GameStore {
     return mapGameRow(result.rows[0]);
   }
 
-  private async createMatchGame(client: Queryable, passphraseHash: string): Promise<PersistedGame> {
+  private async createMatchGame(client: TransactionClient, passphraseHash: string): Promise<PersistedGame> {
     const gameId = randomUUID();
     const nowMs = Date.now();
     const nowIso = new Date(nowMs).toISOString();
@@ -885,7 +490,7 @@ export class PostgresStore implements GameStore {
     };
   }
 
-  private async updateGame(client: Queryable, game: PersistedGame, previousVersion: number): Promise<void> {
+  private async updateGame(client: TransactionClient, game: PersistedGame, previousVersion: number): Promise<void> {
     const result = await client.query(
       `UPDATE games
        SET

--- a/server/src/storeClockLogic.ts
+++ b/server/src/storeClockLogic.ts
@@ -1,0 +1,137 @@
+import type { PersistedGame } from "./storeTypes";
+import { oppositeSeat } from "./storeSeatLogic";
+
+export type TurnClockProjection = {
+  remainingMainSeconds: number;
+  remainingByoSeconds: number;
+  timedOut: boolean;
+};
+
+export type SnapshotClockProjection = {
+  mainSecondsBlack: number;
+  mainSecondsWhite: number;
+  byoSecondsBlack: number;
+  byoSecondsWhite: number;
+  turnStartedAtMs: number;
+  timedOut: boolean;
+};
+
+export function getElapsedWholeSeconds(turnStartedAtMs: number, nowMs: number): number {
+  return Math.floor(Math.max(0, nowMs - turnStartedAtMs) / 1000);
+}
+
+export function projectTurnClock(mainSeconds: number, byoSeconds: number, elapsedSeconds: number): TurnClockProjection {
+  if (elapsedSeconds <= 0) {
+    return {
+      remainingMainSeconds: mainSeconds,
+      remainingByoSeconds: byoSeconds,
+      timedOut: false,
+    };
+  }
+
+  if (elapsedSeconds <= mainSeconds) {
+    return {
+      remainingMainSeconds: mainSeconds - elapsedSeconds,
+      remainingByoSeconds: byoSeconds,
+      timedOut: false,
+    };
+  }
+
+  const overtime = elapsedSeconds - mainSeconds;
+  return {
+    remainingMainSeconds: 0,
+    remainingByoSeconds: Math.max(0, byoSeconds - overtime),
+    timedOut: overtime > byoSeconds,
+  };
+}
+
+export function projectClockForSnapshot(game: PersistedGame, nowMs: number): SnapshotClockProjection {
+  const base: SnapshotClockProjection = {
+    mainSecondsBlack: game.mainSecondsBlack,
+    mainSecondsWhite: game.mainSecondsWhite,
+    byoSecondsBlack: game.byoSecondsBlack,
+    byoSecondsWhite: game.byoSecondsWhite,
+    turnStartedAtMs: game.turnStartedAtMs,
+    timedOut: false,
+  };
+
+  if (game.status !== "active") {
+    return base;
+  }
+
+  const elapsedSeconds = getElapsedWholeSeconds(game.turnStartedAtMs, nowMs);
+  if (elapsedSeconds <= 0) {
+    return base;
+  }
+
+  if (game.turn === "black") {
+    const projected = projectTurnClock(game.mainSecondsBlack, game.byoSecondsBlack, elapsedSeconds);
+    return {
+      ...base,
+      mainSecondsBlack: projected.remainingMainSeconds,
+      byoSecondsBlack: projected.remainingByoSeconds,
+      turnStartedAtMs: game.turnStartedAtMs + elapsedSeconds * 1000,
+      timedOut: projected.timedOut,
+    };
+  }
+
+  const projected = projectTurnClock(game.mainSecondsWhite, game.byoSecondsWhite, elapsedSeconds);
+  return {
+    ...base,
+    mainSecondsWhite: projected.remainingMainSeconds,
+    byoSecondsWhite: projected.remainingByoSeconds,
+    turnStartedAtMs: game.turnStartedAtMs + elapsedSeconds * 1000,
+    timedOut: projected.timedOut,
+  };
+}
+
+export function consumeElapsedClock(game: PersistedGame, nowMs: number): boolean {
+  if (game.status !== "active") {
+    return false;
+  }
+
+  const elapsedSeconds = getElapsedWholeSeconds(game.turnStartedAtMs, nowMs);
+  if (elapsedSeconds <= 0) {
+    return false;
+  }
+
+  if (game.turn === "black") {
+    const projected = projectTurnClock(game.mainSecondsBlack, game.byoSecondsBlack, elapsedSeconds);
+    game.mainSecondsBlack = projected.remainingMainSeconds;
+    game.turnStartedAtMs += elapsedSeconds * 1000;
+    if (!projected.timedOut) {
+      return false;
+    }
+  } else {
+    const projected = projectTurnClock(game.mainSecondsWhite, game.byoSecondsWhite, elapsedSeconds);
+    game.mainSecondsWhite = projected.remainingMainSeconds;
+    game.turnStartedAtMs += elapsedSeconds * 1000;
+    if (!projected.timedOut) {
+      return false;
+    }
+  }
+
+  game.status = "finished";
+  game.resultType = "timeout";
+  game.winner = oppositeSeat(game.turn);
+  game.updatedAt = new Date(nowMs).toISOString();
+  game.version += 1;
+  return true;
+}
+
+export function settleTimeoutIfNeeded(game: PersistedGame, nowMs: number): boolean {
+  const projected = projectClockForSnapshot(game, nowMs);
+  if (!projected.timedOut) {
+    return false;
+  }
+
+  game.mainSecondsBlack = projected.mainSecondsBlack;
+  game.mainSecondsWhite = projected.mainSecondsWhite;
+  game.turnStartedAtMs = projected.turnStartedAtMs;
+  game.status = "finished";
+  game.resultType = "timeout";
+  game.winner = oppositeSeat(game.turn);
+  game.updatedAt = new Date(nowMs).toISOString();
+  game.version += 1;
+  return true;
+}

--- a/server/src/storeDbUtils.ts
+++ b/server/src/storeDbUtils.ts
@@ -1,0 +1,28 @@
+export function toIsoNow(): string {
+  return new Date().toISOString();
+}
+
+export function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+export function toNumber(value: number | string | bigint | null | undefined): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+export function splitSqlStatements(script: string): string[] {
+  return script
+    .split(/;\s*(?:\r?\n|$)/g)
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+}

--- a/server/src/storeGameTransforms.ts
+++ b/server/src/storeGameTransforms.ts
@@ -1,0 +1,122 @@
+import type { Game, MoveRecord, Player } from "./types";
+import type { GameRow, MoveRow, PersistedGame, PlayerRow } from "./storeTypes";
+import { toIso, toNumber } from "./storeDbUtils";
+import { projectClockForSnapshot } from "./storeClockLogic";
+import { oppositeSeat } from "./storeSeatLogic";
+
+export function toGame(snapshot: PersistedGame): Game {
+  return {
+    id: snapshot.id,
+    status: snapshot.status,
+    turn: snapshot.turn,
+    state: snapshot.state,
+    mainSecondsBlack: snapshot.mainSecondsBlack,
+    mainSecondsWhite: snapshot.mainSecondsWhite,
+    byoSecondsBlack: snapshot.byoSecondsBlack,
+    byoSecondsWhite: snapshot.byoSecondsWhite,
+    resultType: snapshot.resultType,
+    winner: snapshot.winner,
+    version: snapshot.version,
+    turnStartedAtMs: snapshot.turnStartedAtMs,
+    createdAt: snapshot.createdAt,
+    updatedAt: snapshot.updatedAt,
+  };
+}
+
+export function toPersistedGame(game: Game, joinTokenHash = ""): PersistedGame {
+  return {
+    id: game.id,
+    status: game.status,
+    turn: game.turn,
+    state: game.state,
+    mainSecondsBlack: game.mainSecondsBlack,
+    mainSecondsWhite: game.mainSecondsWhite,
+    byoSecondsBlack: game.byoSecondsBlack,
+    byoSecondsWhite: game.byoSecondsWhite,
+    resultType: game.resultType,
+    winner: game.winner,
+    version: game.version,
+    turnStartedAtMs: game.turnStartedAtMs,
+    createdAt: game.createdAt,
+    updatedAt: game.updatedAt,
+    joinTokenHash,
+  };
+}
+
+export function toProjectedGame(snapshot: PersistedGame, nowMs: number): Game {
+  if (snapshot.status !== "active") {
+    return toGame(snapshot);
+  }
+
+  const projected = projectClockForSnapshot(snapshot, nowMs);
+  if (projected.timedOut) {
+    return {
+      ...toGame(snapshot),
+      mainSecondsBlack: projected.mainSecondsBlack,
+      mainSecondsWhite: projected.mainSecondsWhite,
+      byoSecondsBlack: projected.byoSecondsBlack,
+      byoSecondsWhite: projected.byoSecondsWhite,
+      turnStartedAtMs: projected.turnStartedAtMs,
+      status: "finished",
+      resultType: "timeout",
+      winner: oppositeSeat(snapshot.turn),
+      version: snapshot.version + 1,
+      updatedAt: new Date(nowMs).toISOString(),
+    };
+  }
+
+  return {
+    ...toGame(snapshot),
+    mainSecondsBlack: projected.mainSecondsBlack,
+    mainSecondsWhite: projected.mainSecondsWhite,
+    byoSecondsBlack: projected.byoSecondsBlack,
+    byoSecondsWhite: projected.byoSecondsWhite,
+    turnStartedAtMs: projected.turnStartedAtMs,
+  };
+}
+
+export function mapGameRow(row: GameRow): PersistedGame {
+  const updatedAt = toIso(row.updated_at);
+  const persistedTurnStartedAtMs = toNumber(row.turn_started_at_ms);
+  const fallbackTurnStartedAtMs = new Date(updatedAt).getTime();
+
+  return {
+    id: row.id,
+    status: row.status,
+    turn: row.turn,
+    state: row.state_json,
+    mainSecondsBlack: toNumber(row.main_seconds_black),
+    mainSecondsWhite: toNumber(row.main_seconds_white),
+    byoSecondsBlack: toNumber(row.byo_seconds_black),
+    byoSecondsWhite: toNumber(row.byo_seconds_white),
+    resultType: row.result_type,
+    winner: row.winner,
+    version: toNumber(row.version),
+    turnStartedAtMs: persistedTurnStartedAtMs > 0 ? persistedTurnStartedAtMs : fallbackTurnStartedAtMs,
+    createdAt: toIso(row.created_at),
+    updatedAt,
+    joinTokenHash: row.join_token_hash,
+  };
+}
+
+export function mapPlayerRow(row: PlayerRow): Player {
+  return {
+    id: row.id,
+    gameId: row.game_id,
+    seat: row.seat,
+    guestId: row.guest_id,
+    displayName: row.display_name,
+    sessionTokenHash: row.session_token_hash,
+    joinedAt: toIso(row.joined_at),
+  };
+}
+
+export function mapMoveRow(row: MoveRow): MoveRecord {
+  return {
+    ply: toNumber(row.ply),
+    actorSeat: row.actor_seat,
+    move: row.move_json,
+    stateAfter: row.state_json_after,
+    createdAt: toIso(row.created_at),
+  };
+}

--- a/server/src/storeMigrations.ts
+++ b/server/src/storeMigrations.ts
@@ -1,0 +1,19 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { splitSqlStatements } from "./storeDbUtils";
+
+let migrationScriptsPromise: Promise<string[]> | null = null;
+
+async function loadMigrationScripts(): Promise<string[]> {
+  const migrationDir = fileURLToPath(new URL("../db/migrations", import.meta.url));
+  const files = (await readdir(migrationDir)).filter((file) => file.endsWith(".sql")).sort();
+  return Promise.all(files.map((file) => readFile(path.join(migrationDir, file), "utf8")));
+}
+
+export async function getMigrationScripts(): Promise<string[]> {
+  if (!migrationScriptsPromise) {
+    migrationScriptsPromise = loadMigrationScripts();
+  }
+  return migrationScriptsPromise;
+}

--- a/server/src/storeSeatLogic.ts
+++ b/server/src/storeSeatLogic.ts
@@ -1,0 +1,31 @@
+import { randomUUID } from "node:crypto";
+import type { Seat } from "./types";
+
+export function createJoinToken(): string {
+  return randomUUID().replaceAll("-", "");
+}
+
+export function pickAvailableSeat(seats: readonly Seat[]): Seat | null {
+  if (!seats.includes("black")) {
+    return "black";
+  }
+  if (!seats.includes("white")) {
+    return "white";
+  }
+  return null;
+}
+
+export function pickRandomSeat(): Seat {
+  return Math.random() < 0.5 ? "black" : "white";
+}
+
+export function pickLobbySeat(seats: readonly Seat[]): Seat | null {
+  if (seats.length === 0) {
+    return pickRandomSeat();
+  }
+  return pickAvailableSeat(seats);
+}
+
+export function oppositeSeat(seat: Seat): Seat {
+  return seat === "black" ? "white" : "black";
+}

--- a/server/src/storeTypes.ts
+++ b/server/src/storeTypes.ts
@@ -1,0 +1,78 @@
+import type { GameState, Move } from "../../core/src/types";
+import type { Game, MoveRecord, Player, Seat } from "./types";
+
+export type DbQueryResult<T> = {
+  rows: T[];
+  rowCount: number | null;
+};
+
+export type Queryable = {
+  query<T extends Record<string, unknown>>(text: string, params?: readonly unknown[]): Promise<DbQueryResult<T>>;
+};
+
+export type TransactionClient = Queryable & {
+  release: () => void;
+};
+
+export type PoolLike = Queryable & {
+  connect: () => Promise<TransactionClient>;
+  end?: () => Promise<void>;
+};
+
+export type PersistedGame = {
+  id: string;
+  status: Game["status"];
+  turn: Seat;
+  state: GameState;
+  mainSecondsBlack: number;
+  mainSecondsWhite: number;
+  byoSecondsBlack: number;
+  byoSecondsWhite: number;
+  resultType: Game["resultType"] | null;
+  winner: Seat | null;
+  version: number;
+  turnStartedAtMs: number;
+  createdAt: string;
+  updatedAt: string;
+  joinTokenHash: string;
+};
+
+export type GameRow = {
+  id: string;
+  status: Game["status"];
+  turn: Seat;
+  state_json: GameState;
+  main_seconds_black: number | string;
+  main_seconds_white: number | string;
+  byo_seconds_black: number | string;
+  byo_seconds_white: number | string;
+  result_type: Game["resultType"] | null;
+  winner: Seat | null;
+  version: number | string;
+  turn_started_at_ms: number | string | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+  join_token_hash: string;
+};
+
+export type PlayerRow = {
+  id: string;
+  game_id: string;
+  seat: Seat;
+  guest_id: string;
+  display_name: string;
+  session_token_hash: string;
+  joined_at: string | Date;
+};
+
+export type MoveRow = {
+  ply: number | string;
+  actor_seat: Seat;
+  move_json: Move;
+  state_json_after: GameState;
+  created_at: string | Date;
+};
+
+export type LastPlyRow = {
+  ply: number | string;
+};


### PR DESCRIPTION
## 概要

プロジェクト全体のリファクタリングを実施。機能変更なし。

### Phase 1: デッドコード削除
- ポーリング廃止後の残骸（`getPollingIntervalMs`等）を削除
- UI未使用のバリデーション関数（`validateCreateGameForm`, `validateJoinGameForm`）を削除
- 未使用の`toDisplayPosition`, `normalizeTimeControl`を削除
- `formatSeconds`のexportを削除（内部利用のみ）
- 対応するテストも修正

### Phase 2: store.ts 分割（1290行 → 6モジュール + 本体）
- `storeTypes.ts`: DB抽象型・行型定義
- `storeDbUtils.ts`: `toIsoNow`, `toIso`, `toNumber`, `splitSqlStatements`
- `storeSeatLogic.ts`: 席選択・トークン生成ロジック
- `storeClockLogic.ts`: 時計投影・タイムアウト処理
- `storeGameTransforms.ts`: Game ⇔ PersistedGame変換・行マッピング
- `storeMigrations.ts`: マイグレーションスクリプト読み込み

### Phase 3: App.tsx カスタムフック抽出（1260行 → 約1050行）
- `useGameClock`: 時計状態管理・250ms更新・表示用投影
- `useGameWebSocket`: WebSocket接続・再接続ロジック
- `useBotTurn`: Bot着手のsetTimeout処理

## テスト計画
- [x] `npm run test` — 全133テスト通過（各コミットで確認済み）
- [x] `npm run build` — ビルド成功（各コミットで確認済み）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)